### PR TITLE
Improve layout spacing and alignment in Settings page

### DIFF
--- a/frontend/src/pages/SettingsPage.jsx
+++ b/frontend/src/pages/SettingsPage.jsx
@@ -13,8 +13,8 @@ const SettingsPage = () => {
   const navigate = useNavigate();
 
   return (
-    <div className="h-full overflow-y-auto bg-base-100 pt-20 px-4 pb-8">
-      <div className="mx-auto max-w-5xl space-y-8">
+    <div className="h-full overflow-y-auto bg-base-100 pt-20 px-4 sm:px-6 lg:px-8 pb-8">
+      <div className="mx-auto max-w-5xl space-y-8 mt-[-45px]">
         {/* Header */}
         <div className="flex items-center gap-4">
           <button


### PR DESCRIPTION
Fixes #5
<img width="1701" height="692" alt="image" src="https://github.com/user-attachments/assets/d29506b0-bf3d-4170-875f-07f5835caed4" />

Adjusted container width to improve horizontal spacing and visual alignment on the Settings page.
