### PR TITLE
Fix video/voide call issue

### DIFF
--- a/frontend/src/components/call/CallRoom.jsx
+++ b/frontend/src/components/call/CallRoom.jsx
@@ -7,8 +7,7 @@ const CallRoom = () => {
   const containerRef = useRef(null);
   const zegoRef = useRef(null);
 
-  const { callStatus, callType, roomId, endCall, isGroupCall } =
-    useCallStore();
+  const { callStatus, callType, roomId, endCall, isGroupCall } = useCallStore();
   const { authUser } = useAuthStore();
 
   useEffect(() => {
@@ -19,12 +18,17 @@ const CallRoom = () => {
     const appID = Number(import.meta.env.VITE_ZEGO_APP_ID);
     const serverSecret = import.meta.env.VITE_ZEGO_SERVER_SECRET;
 
+    console.log("AppID:", appID);
+    console.log("ServerSecret:", serverSecret);
+    console.log("RoomID:", roomId);
+    console.log("UserID:", String(authUser._id));
+
     const kitToken = ZegoUIKitPrebuilt.generateKitTokenForTest(
       appID,
       serverSecret,
       roomId,
       String(authUser._id),
-      authUser.fullName || "User"
+      authUser.fullName || "User",
     );
 
     const zego = ZegoUIKitPrebuilt.create(kitToken);


### PR DESCRIPTION
## Fixes - #11  
### Fixed Video/Voice Call Failing (ZEGOCLOUD 20021 Error)

### Problem

Video and voice calls were failing with the following errors:

- `error 20021`
- `server error=200101`
- `login error { code: 1002099, msg: 'liveroom error' }`

Calls were not connecting even though:

- AppID was correct  
- ServerSecret was correct  
- Token generation was working  
- RoomID and UserID were valid  

---

### Root Cause

The ZEGOCLOUD 30-day trial had expired, which automatically disabled RTC services for the project.

Because the RTC service was inactive:

- The SDK failed to fetch app configuration  
- Room login was rejected  
- Token validation failed at the server level  

This resulted in the `20021` error.

---

### Solution

- Created a new ZEGOCLOUD project with an active trial  
- Enabled RTC service  
- Updated environment variables:
  - `VITE_ZEGO_APP_ID`
  - `VITE_ZEGO_SERVER_SECRET`
- Restarted the development server  

No frontend logic changes were required.

---

### Result

- Video calls working  
- Voice calls working  
- Room login successful  
- No more `20021` or `1002099` errors  