### PR TITLE
Add group profile image upload and update support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,10 @@ backend/node_modules/
 .env
 dist/
 build/
+
+# Python virtual environment
+ml-service/venv/
+
+# Python cache
+__pycache__/
+*.pyc

--- a/backend/src/controllers/group.controller.js
+++ b/backend/src/controllers/group.controller.js
@@ -1,6 +1,7 @@
-import mongoose from "mongoose";
 import Group from "../models/group.model.js";
 import User from "../models/user.model.js";
+import cloudinary from "../lib/cloudinary.js";
+import mongoose from "mongoose";
 
 // GET MY GROUPS
 export const getMyGroups = async (req, res) => {
@@ -51,10 +52,15 @@ export const createGroup = async (req, res) => {
       userId: id,
       role: id === userId.toString() ? "admin" : "member",
     }));
-
+    // upload avatar to cloudinary
+    let avatarUrl = "";
+    if (avatar) {
+      const uploadResponse = await cloudinary.uploader.upload(avatar);
+      avatarUrl = uploadResponse.secure_url;
+    }
     const group = await Group.create({
       name,
-      avatar,
+      avatar: avatarUrl,
       members: groupMembers,
       createdBy: userId,
     });
@@ -214,10 +220,24 @@ export const updateGroup = async (req, res) => {
     }
 
     if (name) group.name = name;
-    if (avatar !== undefined) group.avatar = avatar;
+    if (avatar !== undefined) {
+      if (avatar) {
+        const uploadResponse = await cloudinary.uploader.upload(avatar, {
+          folder: "groups",
+        });
+        group.avatar = uploadResponse.secure_url;
+      } else {
+        group.avatar = "";
+      }
+    }
 
     await group.save();
-    res.status(200).json(group);
+
+    const updatedGroup = await Group.findById(group._id)
+      .populate("members.userId", "fullName profilePic email")
+      .populate("createdBy", "_id");
+
+    res.status(200).json(updatedGroup);
   } catch (error) {
     console.error("Update group error:", error);
     res.status(500).json({ message: "Server error" });

--- a/backend/src/controllers/group.controller.js
+++ b/backend/src/controllers/group.controller.js
@@ -55,7 +55,17 @@ export const createGroup = async (req, res) => {
     // upload avatar to cloudinary
     let avatarUrl = "";
     if (avatar) {
-      const uploadResponse = await cloudinary.uploader.upload(avatar);
+      // Basic validation for base64 image
+      if (!avatar.startsWith("data:image/")) {
+        return res.status(400).json({
+          message: "Only image files are allowed",
+        });
+      }
+
+      const uploadResponse = await cloudinary.uploader.upload(avatar, {
+        folder: "groups",
+      });
+
       avatarUrl = uploadResponse.secure_url;
     }
     const group = await Group.create({

--- a/frontend/src/components/ChangeGroupInfoModal.jsx
+++ b/frontend/src/components/ChangeGroupInfoModal.jsx
@@ -1,11 +1,28 @@
-import { useState } from "react";
-import toast from "react-hot-toast";
 import { axiosInstance } from "../lib/axios";
+import toast from "react-hot-toast";
+import { useChatStore } from "../store/useChatStore";
+import { useState } from "react";
 
 const ChangeGroupInfoModal = ({ group, onClose, onUpdateGroup }) => {
   const [name, setName] = useState(group.name);
+  const [avatar, setAvatar] = useState(group?.avatar || "");
+  const [avatarPreview, setAvatarPreview] = useState(
+    group?.avatar || "/group.png"
+  );
   const [loading, setLoading] = useState(false);
+  const { getGroups } = useChatStore();
+  const handleImageChange = (e) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
 
+    const reader = new FileReader();
+    reader.onloadend = () => {
+      const result = reader.result;
+      setAvatar(result);
+      setAvatarPreview(result);
+    };
+    reader.readAsDataURL(file);
+  };
   const handleSave = async () => {
     if (!name.trim()) {
       toast.error("Group name is required");
@@ -16,9 +33,10 @@ const ChangeGroupInfoModal = ({ group, onClose, onUpdateGroup }) => {
     try {
       const res = await axiosInstance.patch(
         `/groups/${group._id}/update`,
-        { name }
+        { name, avatar, }
       );
       onUpdateGroup(res.data);
+      await getGroups();
       toast.success("Group updated");
       onClose();
     } catch {
@@ -37,7 +55,19 @@ const ChangeGroupInfoModal = ({ group, onClose, onUpdateGroup }) => {
             ✕
           </button>
         </div>
-
+        <div className="flex flex-col items-center gap-2">
+          <img
+            src={avatarPreview}
+            alt="Group Preview"
+            className="h-24 w-24 rounded-full border object-cover"
+          />
+          <input
+            type="file"
+            accept="image/*"
+            className="file-input file-input-bordered file-input-sm w-full"
+            onChange={handleImageChange}
+          />
+        </div>
         <div className="form-control">
           <label className="label">
             <span className="label-text">Group Name</span>

--- a/frontend/src/components/ChangeGroupInfoModal.jsx
+++ b/frontend/src/components/ChangeGroupInfoModal.jsx
@@ -7,14 +7,22 @@ const ChangeGroupInfoModal = ({ group, onClose, onUpdateGroup }) => {
   const [name, setName] = useState(group.name);
   const [avatar, setAvatar] = useState(group?.avatar || "");
   const [avatarPreview, setAvatarPreview] = useState(
-    group?.avatar || "/group.png"
+    group?.avatar || "/group.png",
   );
   const [loading, setLoading] = useState(false);
   const { getGroups } = useChatStore();
   const handleImageChange = (e) => {
     const file = e.target.files?.[0];
     if (!file) return;
+    if (!file.type.startsWith("image/")) {
+      toast.error("Please select an image file");
+      return;
+    }
 
+    if (file.size > 5 * 1024 * 1024) {
+      toast.error("Image size must be less than 5 MB");
+      return;
+    }
     const reader = new FileReader();
     reader.onloadend = () => {
       const result = reader.result;
@@ -31,10 +39,10 @@ const ChangeGroupInfoModal = ({ group, onClose, onUpdateGroup }) => {
 
     setLoading(true);
     try {
-      const res = await axiosInstance.patch(
-        `/groups/${group._id}/update`,
-        { name, avatar, }
-      );
+      const res = await axiosInstance.patch(`/groups/${group._id}/update`, {
+        name,
+        avatar,
+      });
       onUpdateGroup(res.data);
       await getGroups();
       toast.success("Group updated");
@@ -81,10 +89,7 @@ const ChangeGroupInfoModal = ({ group, onClose, onUpdateGroup }) => {
         </div>
 
         <div className="flex justify-end gap-2">
-          <button
-            onClick={onClose}
-            className="btn btn-sm btn-ghost"
-          >
+          <button onClick={onClose} className="btn btn-sm btn-ghost">
             Cancel
           </button>
           <button

--- a/frontend/src/components/ChatHeader.jsx
+++ b/frontend/src/components/ChatHeader.jsx
@@ -1,22 +1,23 @@
+import { AnimatePresence, motion } from "framer-motion";
 import {
-  X,
-  Info,
   ArrowLeft,
-  MoreVertical,
-  Trash2,
-  Sparkles,
-  Phone,
-  Video,
   Image,
-  Trash,
+  Info,
+  MoreVertical,
+  Phone,
   Search,
+  Sparkles,
+  Trash,
+  Trash2,
+  Video,
+  X,
 } from "lucide-react";
-import { useState, useRef, useEffect } from "react";
-import { motion, AnimatePresence } from "framer-motion";
-import { useAuthStore } from "../store/useAuthStore";
-import { useChatStore } from "../store/useChatStore";
+import { useEffect, useRef, useState } from "react";
+
 import GroupMembersModal from "./GroupMembersModal";
+import { useAuthStore } from "../store/useAuthStore";
 import { useCallStore } from "../store/useCallStore";
+import { useChatStore } from "../store/useChatStore";
 
 const ChatHeader = () => {
   const {
@@ -126,23 +127,39 @@ const ChatHeader = () => {
 
             <div className="shrink-0">
               {isGroup ? (
-                <div className="h-9 w-9 sm:h-12 sm:w-12 rounded-xl bg-primary/10 flex items-center justify-center border border-primary/20">
-                  <span className="font-bold text-primary text-sm sm:text-lg">
-                    {selectedGroup.name[0].toUpperCase()}
-                  </span>
-                </div>
+                selectedGroup?.avatar ? (
+                  <img
+                    src={selectedGroup.avatar}
+                    alt={selectedGroup.name}
+                    className="h-9 w-9 sm:h-12 sm:w-12 rounded-full object-cover ring-2 ring-base-200"
+                  />
+                ) : (
+                  <div className="h-9 w-9 sm:h-12 sm:w-12 rounded-xl bg-primary/10 flex items-center justify-center border border-primary/20">
+                    <span className="font-bold text-primary text-sm sm:text-lg">
+                      {selectedGroup.name[0].toUpperCase()}
+                    </span>
+                  </div>
+                )
               ) : (
                 <div className="relative">
                   <img
-                    src={selectedUser?.profilePic || "/avatar.png"}
-                    alt="avatar"
+                    src={
+                      isGroup
+                        ? selectedGroup?.avatar || "/group.png"
+                        : selectedUser?.profilePic || "/avatar.png"
+                    }
+                    alt={isGroup ? selectedGroup?.name : "avatar"}
                     className={`h-9 w-9 sm:h-12 sm:w-12 rounded-full object-cover ring-2 ring-base-200 ${
                       isAI ? "border-2 border-primary/30 animate-pulse" : ""
                     }`}
                   />
-                  {!isAI && onlineUsers.includes(selectedUser?._id) && (
-                    <span className="absolute bottom-0 right-0 h-2.5 w-2.5 rounded-full bg-success border-2 border-base-100" />
-                  )}
+
+                  {!isGroup &&
+                    !isAI &&
+                    onlineUsers.includes(selectedUser?._id) && (
+                      <span className="absolute bottom-0 right-0 h-2.5 w-2.5 rounded-full bg-success border-2 border-base-100" />
+                    )}
+
                   {isAI && isAILoading && (
                     <span className="absolute inset-0 rounded-full border-2 border-primary animate-ping opacity-20" />
                   )}
@@ -371,8 +388,6 @@ const ChatHeader = () => {
           </div>
         </div>
       </div>
-
-      
     </header>
   );
 };

--- a/frontend/src/components/CreateGroupModal.jsx
+++ b/frontend/src/components/CreateGroupModal.jsx
@@ -11,24 +11,32 @@ const CreateGroupModal = ({ onClose }) => {
   const [selectedUsers, setSelectedUsers] = useState([]);
   const [isLoading, setIsLoading] = useState(false);
   const [avatar, setAvatar] = useState("");
-  
+
   const handleImageSelect = (e) => {
-  const file = e.target.files?.[0];
-  if (!file) return;
+    const file = e.target.files?.[0];
+    if (!file) return;
+    if (!file.type.startsWith("image/")) {
+      toast.error("Please select an image file");
+      return;
+    }
 
-  const reader = new FileReader();
-  reader.readAsDataURL(file);
+    if (file.size > 5 * 1024 * 1024) {
+      toast.error("Image size must be less than 5 MB");
+      return;
+    }
+    const reader = new FileReader();
+    reader.readAsDataURL(file);
 
-  reader.onloadend = () => {
-    setAvatar(reader.result);
+    reader.onloadend = () => {
+      setAvatar(reader.result);
+    };
   };
-};
 
   const toggleUser = (userId) => {
     setSelectedUsers((prev) =>
       prev.includes(userId)
         ? prev.filter((id) => id !== userId)
-        : [...prev, userId]
+        : [...prev, userId],
     );
   };
 
@@ -57,10 +65,10 @@ const CreateGroupModal = ({ onClose }) => {
         members: humanMembers,
         avatar,
       });
-    console.log(res.data);
+
       toast.success("Group created");
 
-      await getGroups();          // refresh sidebar
+      await getGroups(); // refresh sidebar
       setSelectedGroup(res.data); // auto-open group
       onClose();
     } catch (err) {
@@ -79,20 +87,20 @@ const CreateGroupModal = ({ onClose }) => {
             <X />
           </button>
         </div>
-    <div className="mb-4 flex flex-col items-center gap-2">
-  <img
-    src={avatar || "/group.png"}
-    alt="Group Avatar"
-    className="h-20 w-20 rounded-full object-cover border"
-  />
+        <div className="mb-4 flex flex-col items-center gap-2">
+          <img
+            src={avatar || "/group.png"}
+            alt="Group Avatar"
+            className="h-20 w-20 rounded-full object-cover border"
+          />
 
-  <input
-    type="file"
-    accept="image/*"
-    onChange={handleImageSelect}
-    className="file-input file-input-bordered file-input-sm w-full"
-  />
-</div>
+          <input
+            type="file"
+            accept="image/*"
+            onChange={handleImageSelect}
+            className="file-input file-input-bordered file-input-sm w-full"
+          />
+        </div>
         <input
           type="text"
           placeholder="Group name"

--- a/frontend/src/components/CreateGroupModal.jsx
+++ b/frontend/src/components/CreateGroupModal.jsx
@@ -1,4 +1,4 @@
-import { X } from "lucide-react";
+import { X, Camera, Search, Users } from "lucide-react";
 import { axiosInstance } from "../lib/axios";
 import toast from "react-hot-toast";
 import { useChatStore } from "../store/useChatStore";
@@ -9,12 +9,14 @@ const CreateGroupModal = ({ onClose }) => {
 
   const [groupName, setGroupName] = useState("");
   const [selectedUsers, setSelectedUsers] = useState([]);
+  const [searchQuery, setSearchQuery] = useState("");
   const [isLoading, setIsLoading] = useState(false);
   const [avatar, setAvatar] = useState("");
 
   const handleImageSelect = (e) => {
     const file = e.target.files?.[0];
     if (!file) return;
+
     if (!file.type.startsWith("image/")) {
       toast.error("Please select an image file");
       return;
@@ -24,9 +26,9 @@ const CreateGroupModal = ({ onClose }) => {
       toast.error("Image size must be less than 5 MB");
       return;
     }
+
     const reader = new FileReader();
     reader.readAsDataURL(file);
-
     reader.onloadend = () => {
       setAvatar(reader.result);
     };
@@ -42,18 +44,17 @@ const CreateGroupModal = ({ onClose }) => {
 
   const createGroup = async () => {
     if (!groupName.trim()) {
-      toast.error("Group name required");
+      toast.error("Group name is required");
       return;
     }
 
-    // FINAL SAFETY: ensure only humans go to backend
     const humanMembers = selectedUsers.filter((id) => {
       const user = users.find((u) => u._id === id);
       return user && !user.isAI;
     });
 
     if (humanMembers.length < 1) {
-      toast.error("Select at least 1 human member");
+      toast.error("Select at least 1 member");
       return;
     }
 
@@ -66,10 +67,9 @@ const CreateGroupModal = ({ onClose }) => {
         avatar,
       });
 
-      toast.success("Group created");
-
-      await getGroups(); // refresh sidebar
-      setSelectedGroup(res.data); // auto-open group
+      toast.success("Group created successfully");
+      await getGroups();
+      setSelectedGroup(res.data);
       onClose();
     } catch (err) {
       toast.error(err.response?.data?.message || "Failed to create group");
@@ -78,71 +78,158 @@ const CreateGroupModal = ({ onClose }) => {
     }
   };
 
+  // Filter out AI users and apply search query filter
+  const filteredUsers = users
+    .filter((u) => !u.isAI)
+    .filter((u) =>
+      u.fullName.toLowerCase().includes(searchQuery.toLowerCase()),
+    );
+
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
-      <div className="w-full max-w-md rounded-xl bg-base-100 p-5 shadow-lg">
-        <div className="mb-4 flex items-center justify-between">
-          <h2 className="text-lg font-semibold">Create Group</h2>
-          <button onClick={onClose}>
-            <X />
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4 animate-in fade-in duration-200">
+      <div className="w-full max-w-md rounded-2xl bg-base-100 shadow-2xl border border-base-300 overflow-hidden flex flex-col max-h-[90vh]">
+        {/* Modal Header */}
+        <div className="flex items-center justify-between border-b border-base-200 px-6 py-4">
+          <h2 className="text-xl font-bold tracking-tight">Create Group</h2>
+          <button
+            onClick={onClose}
+            className="btn btn-ghost btn-sm btn-circle text-base-content/60 hover:text-base-content"
+          >
+            <X className="w-5 h-5" />
           </button>
         </div>
-        <div className="mb-4 flex flex-col items-center gap-2">
-          <img
-            src={avatar || "/group.png"}
-            alt="Group Avatar"
-            className="h-20 w-20 rounded-full object-cover border"
-          />
 
-          <input
-            type="file"
-            accept="image/*"
-            onChange={handleImageSelect}
-            className="file-input file-input-bordered file-input-sm w-full"
-          />
+        {/* Modal Body */}
+        <div className="p-6 overflow-y-auto space-y-5">
+          {/* Avatar Upload */}
+          <div className="flex flex-col items-center gap-2">
+            <label className="relative group cursor-pointer">
+              <div className="w-24 h-24 rounded-full ring-4 ring-primary/20 overflow-hidden bg-base-200 flex items-center justify-center transition-all duration-200 group-hover:ring-primary/40">
+                {avatar ? (
+                  <img
+                    src={avatar}
+                    alt="Group Avatar"
+                    className="w-full h-full object-cover"
+                  />
+                ) : (
+                  /* Stylish Lucide Icon Fallback when no avatar is uploaded */
+                  <Users className="w-10 h-10 text-base-content/40 transition-transform duration-200 group-hover:scale-110" />
+                )}
+              </div>
+
+              {/* Hover Overlay */}
+              <div className="absolute inset-0 bg-black/40 rounded-full flex flex-col items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity duration-200 text-white text-xs font-medium gap-1">
+                <Camera className="w-5 h-5" />
+                <span>{avatar ? "Change" : "Upload"}</span>
+              </div>
+
+              <input
+                type="file"
+                accept="image/*"
+                onChange={handleImageSelect}
+                className="hidden"
+              />
+            </label>
+            <span className="text-xs text-base-content/60 font-medium">
+              Click to choose group picture
+            </span>
+          </div>
+
+          {/* Group Name Input */}
+          <div className="form-control w-full">
+            <label className="label py-1">
+              <span className="label-text font-medium">Group Name</span>
+            </label>
+            <input
+              type="text"
+              placeholder="e.g. Design Team, Weekend Hikers"
+              value={groupName}
+              onChange={(e) => setGroupName(e.target.value)}
+              className="input input-bordered w-full focus:input-primary transition-all"
+            />
+          </div>
+
+          {/* Member Selection Section */}
+          <div className="space-y-2">
+            <div className="flex items-center justify-between">
+              <label className="label-text font-medium">Add Members</label>
+              <span className="badge badge-primary badge-sm font-semibold">
+                {selectedUsers.length} selected
+              </span>
+            </div>
+
+            {/* Search Input */}
+            <div className="relative">
+              <Search className="w-4 h-4 absolute left-3 top-1/2 -translate-y-1/2 text-base-content/40" />
+              <input
+                type="text"
+                placeholder="Search people..."
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                className="input input-sm input-bordered w-full pl-9"
+              />
+            </div>
+
+            {/* User List */}
+            <div className="max-h-52 overflow-y-auto rounded-xl border border-base-200 divide-y divide-base-200">
+              {filteredUsers.length === 0 ? (
+                <div className="p-4 text-center text-sm text-base-content/50">
+                  No members found
+                </div>
+              ) : (
+                filteredUsers.map((user) => {
+                  const isSelected = selectedUsers.includes(user._id);
+                  return (
+                    <label
+                      key={user._id}
+                      className={`flex items-center justify-between p-3 cursor-pointer transition-colors ${
+                        isSelected ? "bg-primary/10" : "hover:bg-base-200/60"
+                      }`}
+                    >
+                      <div className="flex items-center gap-3 min-w-0">
+                        <img
+                          src={user.profilePic || "/avatar.png"}
+                          alt={user.fullName}
+                          className="w-9 h-9 rounded-full object-cover border border-base-300"
+                        />
+                        <span className="font-medium text-sm truncate">
+                          {user.fullName}
+                        </span>
+                      </div>
+
+                      <input
+                        type="checkbox"
+                        className="checkbox checkbox-primary checkbox-sm rounded-md"
+                        checked={isSelected}
+                        onChange={() => toggleUser(user._id)}
+                      />
+                    </label>
+                  );
+                })
+              )}
+            </div>
+          </div>
         </div>
-        <input
-          type="text"
-          placeholder="Group name"
-          value={groupName}
-          onChange={(e) => setGroupName(e.target.value)}
-          className="input input-bordered mb-4 w-full"
-        />
 
-        <div className="mb-4 max-h-60 space-y-2 overflow-y-auto">
-          {users
-            .filter((u) => !u.isAI)
-            .map((user) => (
-              <label
-                key={user._id}
-                className="flex cursor-pointer items-center gap-3 rounded-lg p-2 hover:bg-base-200"
-              >
-                <input
-                  type="checkbox"
-                  className="checkbox checkbox-sm"
-                  checked={selectedUsers.includes(user._id)}
-                  onChange={() => toggleUser(user._id)}
-                />
-                <img
-                  src={user.profilePic || "/avatar.png"}
-                  alt={user.fullName}
-                  className="h-8 w-8 rounded-full"
-                />
-                <span className="truncate">{user.fullName}</span>
-              </label>
-            ))}
-        </div>
-
-        <div className="flex justify-end gap-2">
-          <button onClick={onClose} className="btn btn-ghost">
+        {/* Modal Footer */}
+        <div className="border-t border-base-200 p-4 bg-base-200/30 flex justify-end gap-2">
+          <button
+            onClick={onClose}
+            className="btn btn-ghost btn-sm text-base-content/70"
+            disabled={isLoading}
+          >
             Cancel
           </button>
           <button
             onClick={createGroup}
-            className="btn btn-primary"
+            className="btn btn-primary btn-sm min-w-[100px]"
             disabled={isLoading}
           >
-            {isLoading ? "Creating..." : "Create"}
+            {isLoading ? (
+              <span className="loading loading-spinner loading-xs" />
+            ) : (
+              "Create Group"
+            )}
           </button>
         </div>
       </div>

--- a/frontend/src/components/CreateGroupModal.jsx
+++ b/frontend/src/components/CreateGroupModal.jsx
@@ -1,8 +1,8 @@
-import { useState } from "react";
 import { X } from "lucide-react";
+import { axiosInstance } from "../lib/axios";
 import toast from "react-hot-toast";
 import { useChatStore } from "../store/useChatStore";
-import { axiosInstance } from "../lib/axios";
+import { useState } from "react";
 
 const CreateGroupModal = ({ onClose }) => {
   const { users, setSelectedGroup, getGroups } = useChatStore();
@@ -10,6 +10,19 @@ const CreateGroupModal = ({ onClose }) => {
   const [groupName, setGroupName] = useState("");
   const [selectedUsers, setSelectedUsers] = useState([]);
   const [isLoading, setIsLoading] = useState(false);
+  const [avatar, setAvatar] = useState("");
+  
+  const handleImageSelect = (e) => {
+  const file = e.target.files?.[0];
+  if (!file) return;
+
+  const reader = new FileReader();
+  reader.readAsDataURL(file);
+
+  reader.onloadend = () => {
+    setAvatar(reader.result);
+  };
+};
 
   const toggleUser = (userId) => {
     setSelectedUsers((prev) =>
@@ -42,8 +55,9 @@ const CreateGroupModal = ({ onClose }) => {
       const res = await axiosInstance.post("/groups/create", {
         name: groupName.trim(),
         members: humanMembers,
+        avatar,
       });
-
+    console.log(res.data);
       toast.success("Group created");
 
       await getGroups();          // refresh sidebar
@@ -65,7 +79,20 @@ const CreateGroupModal = ({ onClose }) => {
             <X />
           </button>
         </div>
+    <div className="mb-4 flex flex-col items-center gap-2">
+  <img
+    src={avatar || "/group.png"}
+    alt="Group Avatar"
+    className="h-20 w-20 rounded-full object-cover border"
+  />
 
+  <input
+    type="file"
+    accept="image/*"
+    onChange={handleImageSelect}
+    className="file-input file-input-bordered file-input-sm w-full"
+  />
+</div>
         <input
           type="text"
           placeholder="Group name"

--- a/frontend/src/components/GroupMembersModal.jsx
+++ b/frontend/src/components/GroupMembersModal.jsx
@@ -1,19 +1,21 @@
-import { X, Crown, UserMinus, LogOut, Plus } from "lucide-react";
-import { useEffect, useState } from "react";
-import { motion, AnimatePresence } from "framer-motion";
-import toast from "react-hot-toast";
-import { axiosInstance } from "../lib/axios";
-import { useAuthStore } from "../store/useAuthStore";
+import { AnimatePresence, motion } from "framer-motion";
+import { Camera, Crown, LogOut, Plus, UserMinus, X } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+
 import AddMemberModal from "./AddMemberModal";
+import { axiosInstance } from "../lib/axios";
+import toast from "react-hot-toast";
+import { useAuthStore } from "../store/useAuthStore";
 import { useChatStore } from "../store/useChatStore";
 
 const GroupMembersModal = ({ groupId, onClose }) => {
   const [group, setGroup] = useState(null);
   const [loading, setLoading] = useState(true);
   const [showAddMember, setShowAddMember] = useState(false);
-
+  const fileInputRef = useRef(null);
   const { authUser } = useAuthStore();
-  const { getGroups, clearSelectedChat } = useChatStore();
+  const { getGroups, clearSelectedChat, setSelectedGroup } = useChatStore();
+  const [isUpdatingImage, setIsUpdatingImage] = useState(false);
 
   useEffect(() => {
     const fetchGroup = async () => {
@@ -33,7 +35,9 @@ const GroupMembersModal = ({ groupId, onClose }) => {
   if (loading || !group) return null;
 
   const safeMembers = group.members.filter((m) => m.userId);
-  const myMember = safeMembers.find((m) => m.userId._id === authUser._id);
+  const myMember = safeMembers.find(
+    (m) => (m.userId._id || m.userId).toString() === authUser._id,
+  );
 
   const myRole = myMember?.role;
   const isAdmin = myRole === "admin";
@@ -76,106 +80,177 @@ const GroupMembersModal = ({ groupId, onClose }) => {
       toast.error("Failed to leave group");
     }
   };
+  const handleImageSelect = (e) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    // Validate file type
+    if (!file.type.startsWith("image/")) {
+      toast.error("Please select a valid image.");
+      return;
+    }
+
+    // Validate file size (5 MB)
+    const MAX_SIZE = 5 * 1024 * 1024;
+
+    if (file.size > MAX_SIZE) {
+      toast.error("Image size must be less than 5 MB.");
+      return;
+    }
+    const reader = new FileReader();
+    reader.readAsDataURL(file);
+
+    reader.onload = async () => {
+      setIsUpdatingImage(true);
+      try {
+        const res = await axiosInstance.patch(`/groups/${group._id}/update`, {
+          avatar: reader.result,
+        });
+
+        setGroup(res.data);
+        setSelectedGroup(res.data);
+        await getGroups();
+        toast.success("Group image updated");
+      } catch (err) {
+        toast.error("Failed to update group image");
+      } finally {
+        setIsUpdatingImage(false);
+      }
+    };
+  };
 
   return (
     <>
-    <div className="absolute top-full right-0 mt-3 z-[100] max-sm:fixed max-sm:top-20 max-sm:left-[36.3%] max-sm:-translate-x-1/2">
-      <motion.div
-        initial={{ opacity: 0, scale: 0.95, y: -10 }}
-        animate={{ opacity: 1, scale: 1, y: 0 }}
-        className="w-[92vw] max-w-sm sm:w-96 max-h-[80vh]
+      <div className="absolute top-full right-0 mt-3 z-[100] max-sm:fixed max-sm:top-20 max-sm:left-[36.3%] max-sm:-translate-x-1/2">
+        <motion.div
+          initial={{ opacity: 0, scale: 0.95, y: -10 }}
+          animate={{ opacity: 1, scale: 1, y: 0 }}
+          className="w-[92vw] max-w-sm sm:w-96 max-h-[80vh]
   rounded-3xl bg-base-100 shadow-2xl border border-base-300
   flex flex-col overflow-hidden"
-      >
-        <div className="flex items-center justify-between border-b px-6 py-5">
-          <div>
-            <h2 className="text-xl font-bold">{group.name}</h2>
-            <p className="text-sm opacity-60">{group.members.length} members</p>
-          </div>
-          <button onClick={onClose} className="btn btn-ghost btn-sm btn-circle">
-            <X size={20} />
-          </button>
-        </div>
-
-        {isAdmin && (
-          <div className="px-6 py-4">
-            <button
-              onClick={() => setShowAddMember(true)}
-              className="btn btn-primary w-full gap-2 rounded-xl"
-            >
-              <Plus size={18} /> Add Member
-            </button>
-          </div>
-        )}
-
-        <div className="flex-1 overflow-y-auto px-2 py-2">
-          {safeMembers.map((m) => {
-            const isMe = m.userId._id === authUser._id;
-            const isCreatorMember = m.userId._id === group.createdBy;
-
-            return (
-              <div
-                key={m.userId._id}
-                className="group flex items-center gap-4 rounded-xl p-3 hover:bg-base-200"
-              >
-                <div className="relative">
-                  <img
-                    src={m.userId.profilePic || "/avatar.png"}
-                    className="h-11 w-11 rounded-full"
-                  />
-                  {m.role === "admin" && (
-                    <div className="absolute -bottom-1 -right-1 bg-base-100 rounded-full p-0.5">
-                      <Crown size={14} className="text-warning" />
-                    </div>
-                  )}
-                </div>
-
-                <div className="flex-1 min-w-0">
-                  <p className="font-semibold truncate flex gap-2 items-center">
-                    {m.userId.fullName}
-                    {isMe && (
-                      <span className="text-xs bg-primary/10 text-primary px-2 py-0.5 rounded-full">
-                        You
-                      </span>
-                    )}
-                  </p>
-                  <p className="text-xs capitalize opacity-60">{m.role}</p>
-                </div>
-
-                {isAdmin && !isMe && !isCreatorMember && (
+        >
+          <div className="flex items-center justify-between border-b px-6 py-5">
+            <div className="flex items-center gap-4">
+              <div className="relative">
+                <img
+                  src={group.avatar || "/group.png"}
+                  alt={group.name}
+                  className="h-14 w-14 rounded-full object-cover"
+                />
+                {isAdmin && (
                   <button
-                    onClick={() => handleRemove(m.userId._id)}
-                    className="btn btn-ghost btn-sm btn-circle text-error opacity-0 group-hover:opacity-100"
+                    onClick={() => fileInputRef.current.click()}
+                    disabled={isUpdatingImage}
+                    className="absolute bottom-0 right-0 btn btn-circle btn-xs"
                   >
-                    <UserMinus size={18} />
+                    {isUpdatingImage ? (
+                      <span className="loading loading-spinner loading-sm text-primary"></span>
+                    ) : (
+                      <Camera size={14} />
+                    )}
                   </button>
                 )}
               </div>
-            );
-          })}
-        </div>
 
-        {canLeave && (
-          <div className="border-t p-4">
+              <div>
+                <h2 className="text-xl font-bold">{group.name}</h2>
+                <p className="text-sm opacity-60">
+                  {group.members.length} members
+                </p>
+              </div>
+            </div>
             <button
-              onClick={handleLeave}
-              className="btn btn-ghost w-full text-error gap-2"
+              onClick={onClose}
+              className="btn btn-ghost btn-sm btn-circle"
             >
-              <LogOut size={18} /> Leave Group
+              <X size={20} />
             </button>
           </div>
-        )}
-      </motion.div>
 
-      
-    </div>
-    {showAddMember && (
+          {isAdmin && (
+            <div className="px-6 py-4">
+              <button
+                onClick={() => setShowAddMember(true)}
+                className="btn btn-primary w-full gap-2 rounded-xl"
+              >
+                <Plus size={18} /> Add Member
+              </button>
+            </div>
+          )}
+
+          <div className="flex-1 overflow-y-auto px-2 py-2">
+            {safeMembers.map((m) => {
+              const isMe = m.userId._id === authUser._id;
+              const isCreatorMember = m.userId._id === group.createdBy;
+
+              return (
+                <div
+                  key={m.userId._id}
+                  className="group flex items-center gap-4 rounded-xl p-3 hover:bg-base-200"
+                >
+                  <div className="relative">
+                    <img
+                      src={m.userId.profilePic || "/avatar.png"}
+                      className="h-11 w-11 rounded-full"
+                    />
+                    {m.role === "admin" && (
+                      <div className="absolute -bottom-1 -right-1 bg-base-100 rounded-full p-0.5">
+                        <Crown size={14} className="text-warning" />
+                      </div>
+                    )}
+                  </div>
+
+                  <div className="flex-1 min-w-0">
+                    <p className="font-semibold truncate flex gap-2 items-center">
+                      {m.userId.fullName}
+                      {isMe && (
+                        <span className="text-xs bg-primary/10 text-primary px-2 py-0.5 rounded-full">
+                          You
+                        </span>
+                      )}
+                    </p>
+                    <p className="text-xs capitalize opacity-60">{m.role}</p>
+                  </div>
+
+                  {isAdmin && !isMe && !isCreatorMember && (
+                    <button
+                      onClick={() => handleRemove(m.userId._id)}
+                      className="btn btn-ghost btn-sm btn-circle text-error opacity-0 group-hover:opacity-100"
+                    >
+                      <UserMinus size={18} />
+                    </button>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+
+          {canLeave && (
+            <div className="border-t p-4">
+              <button
+                onClick={handleLeave}
+                className="btn btn-ghost w-full text-error gap-2"
+              >
+                <LogOut size={18} /> Leave Group
+              </button>
+            </div>
+          )}
+        </motion.div>
+      </div>
+      {showAddMember && (
         <AddMemberModal
           group={group}
           onClose={() => setShowAddMember(false)}
           onAdded={(updatedGroup) => setGroup(updatedGroup)}
         />
       )}
+      <input
+        type="file"
+        accept="image/*"
+        hidden
+        ref={fileInputRef}
+        onChange={handleImageSelect}
+      />
     </>
   );
 };

--- a/frontend/src/components/GroupMembersModal.jsx
+++ b/frontend/src/components/GroupMembersModal.jsx
@@ -181,7 +181,9 @@ const GroupMembersModal = ({ groupId, onClose }) => {
           <div className="flex-1 overflow-y-auto px-2 py-2">
             {safeMembers.map((m) => {
               const isMe = m.userId._id === authUser._id;
-              const isCreatorMember = m.userId._id === group.createdBy;
+              const isCreatorMember =
+                m.userId._id.toString() ===
+                (group.createdBy?._id || group.createdBy)?.toString();
 
               return (
                 <div

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -1,9 +1,10 @@
-import { useEffect, useState, useMemo } from "react";
-import { Users, Plus, UsersRound, Trash2, CircleDot } from "lucide-react";
-import { useChatStore } from "../store/useChatStore";
-import { useAuthStore } from "../store/useAuthStore";
-import SidebarSkeleton from "./skeletons/SidebarSkeleton";
+import { CircleDot, Plus, Trash2, Users, UsersRound } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+
 import CreateGroupModal from "./CreateGroupModal";
+import SidebarSkeleton from "./skeletons/SidebarSkeleton";
+import { useAuthStore } from "../store/useAuthStore";
+import { useChatStore } from "../store/useChatStore";
 
 const Sidebar = ({ setActiveTab }) => {
   const {
@@ -109,7 +110,15 @@ const Sidebar = ({ setActiveTab }) => {
                   }`}
                 >
                   <div className="flex items-center gap-3">
-                    <UsersRound className="h-10 w-10 rounded-full bg-primary/10 p-2" />
+                    {group.avatar ? (
+                  <img
+                    src={group.avatar}
+                    alt={group.name}
+                    className="h-10 w-10 rounded-full object-cover"
+                        />
+                     ) : (
+                <UsersRound className="h-10 w-10 rounded-full bg-primary/10 p-2" />
+                         )}
                     <div>
                       <p className="font-medium truncate">{group.name}</p>
                       <p className="text-xs opacity-60">Group chat</p>

--- a/frontend/src/pages/GroupInfoPage.jsx
+++ b/frontend/src/pages/GroupInfoPage.jsx
@@ -1,12 +1,12 @@
 import { useEffect, useState } from "react";
-import { useParams, useNavigate } from "react-router-dom";
-import toast from "react-hot-toast";
-import { axiosInstance } from "../lib/axios";
-import { useAuthStore } from "../store/useAuthStore";
+import { useNavigate, useParams } from "react-router-dom";
 
-import GroupMembersList from "../components/GroupMembersList";
 import AddMemberModal from "../components/AddMemberModal";
 import ChangeGroupInfoModal from "../components/ChangeGroupInfoModal";
+import GroupMembersList from "../components/GroupMembersList";
+import { axiosInstance } from "../lib/axios";
+import toast from "react-hot-toast";
+import { useAuthStore } from "../store/useAuthStore";
 
 const GroupInfoPage = () => {
   const { id: groupId } = useParams();
@@ -18,7 +18,13 @@ const GroupInfoPage = () => {
   const [showAddMember, setShowAddMember] = useState(false);
   const [showEditGroup, setShowEditGroup] = useState(false);
 
-  const isAdmin = group?.admins?.includes(authUser._id);
+  const isAdmin =
+    group?.members?.some((m) => {
+      const memberId = typeof m.userId === "string" ? m.userId : m.userId?._id;
+      return (
+        memberId?.toString() === authUser?._id?.toString() && m.role === "admin"
+      );
+    }) || false;
 
   useEffect(() => {
     const fetchGroup = async () => {
@@ -55,21 +61,35 @@ const GroupInfoPage = () => {
   return (
     <div className="max-w-3xl mx-auto p-6 space-y-6">
       <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-2xl font-bold">{group.name}</h1>
-          <p className="text-sm opacity-60">
-            {group.members.length} members
-          </p>
-        </div>
-
-        {isAdmin && (
+        <div className="flex items-center gap-4">
           <button
-            className="btn btn-sm btn-outline"
+            type="button"
             onClick={() => setShowEditGroup(true)}
+            className="relative"
           >
-            Edit
+            <img
+              src={group?.avatar || "/group.png"}
+              alt={group?.name || "Group"}
+              className="h-16 w-16 rounded-full object-cover border"
+            />
+            <span className="absolute bottom-0 right-0 flex h-6 w-6 items-center justify-center rounded-full bg-primary text-white text-xs">
+              ✎
+            </span>
           </button>
-        )}
+
+          {showEditGroup && (
+            <ChangeGroupInfoModal
+              group={group}
+              onClose={() => setShowEditGroup(false)}
+              onUpdateGroup={setGroup}
+            />
+          )}
+
+          <div>
+            <h1 className="text-2xl font-bold">{group.name}</h1>
+            <p className="text-sm opacity-60">{group.members.length} members</p>
+          </div>
+        </div>
       </div>
 
       <GroupMembersList
@@ -100,14 +120,6 @@ const GroupInfoPage = () => {
         <AddMemberModal
           group={group}
           onClose={() => setShowAddMember(false)}
-          onUpdateGroup={setGroup}
-        />
-      )}
-
-      {showEditGroup && (
-        <ChangeGroupInfoModal
-          group={group}
-          onClose={() => setShowEditGroup(false)}
           onUpdateGroup={setGroup}
         />
       )}


### PR DESCRIPTION
## Summary

Implemented full group profile image support.

### Backend
- Added Cloudinary upload for group images
- Added API to update group profile image
- Added image validation

### Frontend
- Upload image while creating a group
- Update group image from Group Info
- Display image in sidebar
- Display image in chat header
- Display image in group info
- Added loading spinner during upload
- Added fallback image

### Testing
- Created group with image
- Updated existing group image
- Verified sidebar, chat header, and group info updates
- Verified image validation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Create groups with optional avatar upload and instant preview.
  - Edit group avatars from group settings with image validation and upload feedback.

- **Improvements**
  - Persisted group avatars now display in the chat header, sidebar, and group info with sensible fallbacks.
  - Refreshed group/member details after avatar/name updates to keep the UI in sync.
  - Improved admin detection and updated the group header/edit flow.

- **Chores**
  - Expanded repo ignore rules for build outputs and common Python artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
