### PR TITLE
feat(chat): add GIF picker with Giphy integration

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -33,3 +33,6 @@ ML_SERVICE_URL=http://localhost:8000/analyze
 
 # Redis
 REDIS_URL=redis://localhost:6379
+
+# GIPHY
+GIPHY_API_KEY=your_giphy_api_key

--- a/backend/src/controllers/gif.controller.js
+++ b/backend/src/controllers/gif.controller.js
@@ -1,0 +1,37 @@
+import { getTrendingGifs, searchGifs } from "../services/gif.service.js";
+
+// GET /api/gif/trending?offset=0
+export const trendingGifs = async (req, res) => {
+  try {
+    const offset = parseInt(req.query.offset, 10) || 0;
+    const result = await getTrendingGifs({ offset });
+    res.status(200).json(result);
+  } catch (err) {
+    if (err.code === "GIF_PROVIDER_NOT_CONFIGURED") {
+      return res.status(503).json({ message: "GIF provider is not configured" });
+    }
+    console.error("Trending GIFs error:", err.message);
+    res.status(502).json({ message: "Failed to load trending GIFs" });
+  }
+};
+
+// GET /api/gif/search?query=hello&offset=0
+export const searchGifsHandler = async (req, res) => {
+  try {
+    const { query } = req.query;
+    const offset = parseInt(req.query.offset, 10) || 0;
+
+    if (!query?.trim()) {
+      return res.status(200).json({ gifs: [], hasMore: false });
+    }
+
+    const result = await searchGifs({ query: query.trim(), offset });
+    res.status(200).json(result);
+  } catch (err) {
+    if (err.code === "GIF_PROVIDER_NOT_CONFIGURED") {
+      return res.status(503).json({ message: "GIF provider is not configured" });
+    }
+    console.error("GIF search error:", err.message);
+    res.status(502).json({ message: "Failed to search GIFs" });
+  }
+};

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -13,6 +13,7 @@ import seedAIUser from "./seeds/seedAIUser.js";
 import statusRoutes from "./routes/status.routes.js";
 import adminRoutes from "./routes/admin.routes.js";
 import reportRoutes from "./routes/report.routes.js";
+import gifRoutes from "./routes/gif.routes.js";
 
 dotenv.config();
 
@@ -44,6 +45,7 @@ app.use("/api/ai", aiRoutes);
 app.use("/api/status", statusRoutes);
 app.use("/api/admin", adminRoutes);
 app.use("/api/reports", reportRoutes);
+app.use("/api/gif", gifRoutes);
 
 if (process.env.NODE_ENV === "production") {
   app.use(express.static(path.join(__dirname, "../frontend/dist")));

--- a/backend/src/middleware/rateLimiter.js
+++ b/backend/src/middleware/rateLimiter.js
@@ -17,3 +17,12 @@ export const otpRateLimiter = rateLimit({
   },
   skip: () => process.env.NODE_ENV === "test",
 });
+
+export const gifRateLimiter = rateLimit({
+  windowMs: 60 * 1000, // 1 minute
+  max: 30, // max 30 GIF searches/trending calls per IP per minute
+  message: {
+    message: "Too many GIF requests. Please slow down and try again shortly.",
+  },
+  skip: () => process.env.NODE_ENV === "test",
+});

--- a/backend/src/routes/gif.routes.js
+++ b/backend/src/routes/gif.routes.js
@@ -1,0 +1,21 @@
+import express from "express";
+import { trendingGifs, searchGifsHandler } from "../controllers/gif.controller.js";
+import { protectRoute } from "../middleware/auth.middleware.js";
+import { gifRateLimiter } from "../middleware/rateLimiter.js";
+
+const router = express.Router();
+
+/**
+ * GET /api/gif/trending
+ * Protected + rate-limited proxy to the Giphy trending endpoint.
+ * Keeps the Giphy API key server-side only.
+ */
+router.get("/trending", protectRoute, gifRateLimiter, trendingGifs);
+
+/**
+ * GET /api/gif/search?query=hello
+ * Protected + rate-limited proxy to the Giphy search endpoint.
+ */
+router.get("/search", protectRoute, gifRateLimiter, searchGifsHandler);
+
+export default router;

--- a/backend/src/services/gif.service.js
+++ b/backend/src/services/gif.service.js
@@ -1,0 +1,68 @@
+import axios from "axios";
+
+const GIPHY_BASE_URL = "https://api.giphy.com/v1/gifs";
+const DEFAULT_LIMIT = 24;
+
+const mapGif = (gif) => ({
+  id: gif.id,
+  title: gif.title,
+  previewUrl: gif.images?.fixed_width_small?.url || gif.images?.fixed_width?.url,
+  url: gif.images?.original?.url,
+  width: gif.images?.fixed_width?.width,
+  height: gif.images?.fixed_width?.height,
+});
+
+const buildResult = (data) => {
+  const gifs = (data?.data || []).map(mapGif);
+
+  const pagination = data?.pagination || {};
+  const paginationOffset = pagination.offset || 0;
+  const paginationCount = pagination.count || 0;
+  const totalCount = pagination.total_count || 0;
+  const hasMore = paginationOffset + paginationCount < totalCount;
+
+  return { gifs, hasMore };
+};
+
+const ensureApiKey = () => {
+  const apiKey = process.env.GIPHY_API_KEY;
+  if (!apiKey || apiKey === "your_giphy_api_key") {
+    const err = new Error("Giphy API key not configured");
+    err.code = "GIF_PROVIDER_NOT_CONFIGURED";
+    throw err;
+  }
+  return apiKey;
+};
+
+export const getTrendingGifs = async ({ offset = 0, limit = DEFAULT_LIMIT } = {}) => {
+  const apiKey = ensureApiKey();
+
+  const response = await axios.get(`${GIPHY_BASE_URL}/trending`, {
+    params: {
+      api_key: apiKey,
+      limit,
+      offset,
+      rating: "pg-13",
+    },
+    timeout: 8000,
+  });
+
+  return buildResult(response.data);
+};
+
+export const searchGifs = async ({ query, offset = 0, limit = DEFAULT_LIMIT }) => {
+  const apiKey = ensureApiKey();
+
+  const response = await axios.get(`${GIPHY_BASE_URL}/search`, {
+    params: {
+      api_key: apiKey,
+      q: query,
+      limit,
+      offset,
+      rating: "pg-13",
+    },
+    timeout: 8000,
+  });
+
+  return buildResult(response.data);
+};

--- a/frontend/src/components/GifPicker.jsx
+++ b/frontend/src/components/GifPicker.jsx
@@ -1,0 +1,163 @@
+import { useEffect, useRef, useState, useCallback } from "react";
+import { Search, Loader2, X } from "lucide-react";
+import { axiosInstance } from "../lib/axios";
+
+const GifPicker = ({ onSelect, onClose }) => {
+  const [query, setQuery] = useState("");
+  const [gifs, setGifs] = useState([]);
+  const [offset, setOffset] = useState(0);
+  const [hasMore, setHasMore] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [error, setError] = useState(null);
+
+  const debounceRef = useRef(null);
+  const requestIdRef = useRef(0);
+
+  const fetchGifs = useCallback(async (searchQuery, currentOffset, append) => {
+    const requestId = ++requestIdRef.current;
+
+    if (append) {
+      setIsLoadingMore(true);
+    } else {
+      setIsLoading(true);
+      setError(null);
+    }
+
+    try {
+      const endpoint = searchQuery.trim() ? "/gif/search" : "/gif/trending";
+      const params = searchQuery.trim()
+        ? { query: searchQuery.trim(), offset: currentOffset }
+        : { offset: currentOffset };
+
+      const res = await axiosInstance.get(endpoint, { params });
+
+      // Ignore stale responses if a newer request has since started
+      if (requestId !== requestIdRef.current) return;
+
+      setGifs((prev) => (append ? [...prev, ...res.data.gifs] : res.data.gifs));
+      setHasMore(res.data.hasMore);
+      setOffset(currentOffset);
+    } catch (err) {
+      if (requestId !== requestIdRef.current) return;
+
+      const status = err?.response?.status;
+      if (status === 503) {
+        setError("GIF search isn't available right now.");
+      } else {
+        setError("Couldn't load GIFs. Please try again.");
+      }
+      if (!append) setGifs([]);
+    } finally {
+      if (requestId === requestIdRef.current) {
+        setIsLoading(false);
+        setIsLoadingMore(false);
+      }
+    }
+  }, []);
+
+  // Load trending GIFs on mount
+  useEffect(() => {
+    fetchGifs("", 0, false);
+  }, [fetchGifs]);
+
+  // Debounced search as the user types
+  useEffect(() => {
+    clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      fetchGifs(query, 0, false);
+    }, 400);
+
+    return () => clearTimeout(debounceRef.current);
+  }, [query, fetchGifs]);
+
+  const handleLoadMore = () => {
+    if (isLoadingMore || !hasMore) return;
+    fetchGifs(query, offset + 24, true);
+  };
+
+  return (
+    <div className="flex flex-col w-full sm:w-80 h-96 bg-base-100 border border-base-300 sm:rounded-xl shadow-lg overflow-hidden">
+      <div className="flex items-center gap-2 p-2 border-b border-base-300">
+        <div className="relative flex-1">
+          <Search
+            size={16}
+            className="absolute left-2.5 top-1/2 -translate-y-1/2 text-base-content/40"
+          />
+          <input
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search GIFs"
+            autoFocus
+            className="w-full pl-8 pr-2 py-1.5 text-sm rounded-lg bg-base-200 focus:outline-none focus:ring-2 focus:ring-primary/30"
+          />
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          className="btn btn-ghost btn-circle btn-xs"
+        >
+          <X size={14} />
+        </button>
+      </div>
+
+      <div className="flex-1 overflow-y-auto p-2">
+        {isLoading && (
+          <div className="flex items-center justify-center h-full text-base-content/50">
+            <Loader2 size={20} className="animate-spin" />
+          </div>
+        )}
+
+        {!isLoading && error && (
+          <div className="flex items-center justify-center h-full text-center text-sm text-base-content/50 px-4">
+            {error}
+          </div>
+        )}
+
+        {!isLoading && !error && gifs.length === 0 && (
+          <div className="flex items-center justify-center h-full text-sm text-base-content/50">
+            No GIFs found
+          </div>
+        )}
+
+        {!isLoading && !error && gifs.length > 0 && (
+          <div className="grid grid-cols-2 gap-2">
+            {gifs.map((gif) => (
+              <button
+                key={gif.id}
+                type="button"
+                onClick={() => onSelect(gif.url)}
+                className="rounded-lg overflow-hidden border border-transparent hover:border-primary transition-colors"
+              >
+                <img
+                  src={gif.previewUrl}
+                  alt={gif.title || "GIF"}
+                  loading="lazy"
+                  className="w-full h-24 object-cover"
+                />
+              </button>
+            ))}
+          </div>
+        )}
+
+        {!isLoading && !error && hasMore && (
+          <button
+            type="button"
+            onClick={handleLoadMore}
+            disabled={isLoadingMore}
+            className="btn btn-ghost btn-sm w-full mt-2"
+          >
+            {isLoadingMore ? (
+              <Loader2 size={16} className="animate-spin" />
+            ) : (
+              "Load more"
+            )}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default GifPicker;

--- a/frontend/src/components/GifPicker.jsx
+++ b/frontend/src/components/GifPicker.jsx
@@ -13,6 +13,7 @@ const GifPicker = ({ onSelect, onClose }) => {
 
   const debounceRef = useRef(null);
   const requestIdRef = useRef(0);
+  const isFirstRender = useRef(true);
 
   const fetchGifs = useCallback(async (searchQuery, currentOffset, append) => {
     const requestId = ++requestIdRef.current;
@@ -26,27 +27,38 @@ const GifPicker = ({ onSelect, onClose }) => {
 
     try {
       const endpoint = searchQuery.trim() ? "/gif/search" : "/gif/trending";
+
       const params = searchQuery.trim()
-        ? { query: searchQuery.trim(), offset: currentOffset }
-        : { offset: currentOffset };
+        ? {
+            query: searchQuery.trim(),
+            offset: currentOffset,
+          }
+        : {
+            offset: currentOffset,
+          };
 
       const res = await axiosInstance.get(endpoint, { params });
 
-      // Ignore stale responses if a newer request has since started
+      // Ignore stale responses
       if (requestId !== requestIdRef.current) return;
 
-      setGifs((prev) => (append ? [...prev, ...res.data.gifs] : res.data.gifs));
+      setGifs((prev) =>
+        append ? [...prev, ...res.data.gifs] : res.data.gifs
+      );
+
       setHasMore(res.data.hasMore);
       setOffset(currentOffset);
     } catch (err) {
       if (requestId !== requestIdRef.current) return;
 
       const status = err?.response?.status;
+
       if (status === 503) {
         setError("GIF search isn't available right now.");
       } else {
         setError("Couldn't load GIFs. Please try again.");
       }
+
       if (!append) setGifs([]);
     } finally {
       if (requestId === requestIdRef.current) {
@@ -56,14 +68,21 @@ const GifPicker = ({ onSelect, onClose }) => {
     }
   }, []);
 
-  // Load trending GIFs on mount
+  // Initial trending fetch
   useEffect(() => {
     fetchGifs("", 0, false);
   }, [fetchGifs]);
 
-  // Debounced search as the user types
+  // Debounced search
+  // Skip the first render because trending GIFs are already loaded above.
   useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
+
     clearTimeout(debounceRef.current);
+
     debounceRef.current = setTimeout(() => {
       fetchGifs(query, 0, false);
     }, 400);
@@ -73,6 +92,7 @@ const GifPicker = ({ onSelect, onClose }) => {
 
   const handleLoadMore = () => {
     if (isLoadingMore || !hasMore) return;
+
     fetchGifs(query, offset + 24, true);
   };
 
@@ -84,6 +104,7 @@ const GifPicker = ({ onSelect, onClose }) => {
             size={16}
             className="absolute left-2.5 top-1/2 -translate-y-1/2 text-base-content/40"
           />
+
           <input
             type="text"
             value={query}
@@ -93,6 +114,7 @@ const GifPicker = ({ onSelect, onClose }) => {
             className="w-full pl-8 pr-2 py-1.5 text-sm rounded-lg bg-base-200 focus:outline-none focus:ring-2 focus:ring-primary/30"
           />
         </div>
+
         <button
           type="button"
           onClick={onClose}

--- a/frontend/src/components/MessageInput.jsx
+++ b/frontend/src/components/MessageInput.jsx
@@ -7,10 +7,12 @@ import {
   Mic,
   StopCircle,
   Smile,
+  Clapperboard,
 } from "lucide-react";
 import toast from "react-hot-toast";
 import { useChatStore } from "../store/useChatStore";
 import EmojiPicker from "emoji-picker-react";
+import GifPicker from "./GifPicker";
 
 const MessageInput = () => {
   const [text, setText] = useState("");
@@ -19,9 +21,11 @@ const MessageInput = () => {
   const [audioData, setAudioData] = useState(null);
   const [recording, setRecording] = useState(false);
   const [showEmojiPicker, setShowEmojiPicker] = useState(false);
+  const [showGifPicker, setShowGifPicker] = useState(false);
   const [dragActive, setDragActive] = useState(false);
 
   const emojiRef = useRef(null);
+  const gifRef = useRef(null);
   const fileRef = useRef(null);
   const imageRef = useRef(null);
   const mediaRecorderRef = useRef(null);
@@ -55,6 +59,9 @@ const MessageInput = () => {
       if (emojiRef.current && !emojiRef.current.contains(event.target)) {
         setShowEmojiPicker(false);
       }
+      if (gifRef.current && !gifRef.current.contains(event.target)) {
+        setShowGifPicker(false);
+      }
     };
 
     document.addEventListener("mousedown", handleClickOutside);
@@ -76,6 +83,11 @@ const MessageInput = () => {
     const reader = new FileReader();
     reader.onload = () => setImagePreview(reader.result);
     reader.readAsDataURL(file);
+  };
+
+  const handleGifSelect = (gifUrl) => {
+    setImagePreview(gifUrl);
+    setShowGifPicker(false);
   };
 
   const handleFileChange = (e) => {
@@ -372,7 +384,7 @@ const MessageInput = () => {
   "
             />
 
-            {!isAI && (
+{!isAI && (
               <div className="flex items-center gap-0.5 sm:gap-1 ml-2">
                 <input
                   ref={imageRef}
@@ -427,6 +439,36 @@ const MessageInput = () => {
                 >
                   <Image size={18} />
                 </button>
+
+                <div className="relative" ref={gifRef}>
+                  <button
+                    type="button"
+                    onClick={() => setShowGifPicker((prev) => !prev)}
+                    className="btn btn-ghost btn-circle btn-xs sm:btn-sm"
+                  >
+                    <Clapperboard size={18} />
+                  </button>
+
+                  {showGifPicker && (
+                    <div
+                      className="
+                        fixed sm:absolute
+                        bottom-0 sm:bottom-12
+                        left-0 sm:left-auto
+                        right-0
+                        z-50
+                        w-full sm:w-auto
+                        sm:border sm:rounded-xl
+                        shadow-lg
+                      "
+                    >
+                      <GifPicker
+                        onSelect={handleGifSelect}
+                        onClose={() => setShowGifPicker(false)}
+                      />
+                    </div>
+                  )}
+                </div>
 
                 <button
                   type="button"

--- a/frontend/src/components/MessageInput.jsx
+++ b/frontend/src/components/MessageInput.jsx
@@ -403,7 +403,10 @@ const MessageInput = () => {
                 <div className="relative" ref={emojiRef}>
                   <button
                     type="button"
-                    onClick={() => setShowEmojiPicker((prev) => !prev)}
+                    onClick={() => {
+                   setShowGifPicker(false);
+                   setShowEmojiPicker((prev) => !prev);
+                   }}
                     className="btn btn-ghost btn-circle btn-xs sm:btn-sm"
                   >
                     <Smile size={18} />
@@ -443,7 +446,10 @@ const MessageInput = () => {
                 <div className="relative" ref={gifRef}>
                   <button
                     type="button"
-                    onClick={() => setShowGifPicker((prev) => !prev)}
+                    onClick={() => {
+                    setShowEmojiPicker(false);
+                    setShowGifPicker((prev) => !prev);
+                    }}
                     className="btn btn-ghost btn-circle btn-xs sm:btn-sm"
                   >
                     <Clapperboard size={18} />


### PR DESCRIPTION
## What changed

Integrates a GIF picker into the message composer, backed by Giphy, as requested in #118.

- **Backend proxy** (`/api/gif/trending`, `/api/gif/search`) — keeps the Giphy API key server-side only, never exposed to the client. Protected by `protectRoute` and a dedicated rate limiter (30 req/min per IP) to gracefully handle abuse/rate-limit scenarios.
- **`GifPicker` component** — trending GIFs load on open, debounced keyword search (400ms), paginated "Load more," and distinct loading/empty/error states.
- **Composer integration** — new GIF button sits alongside the existing emoji/image/file buttons in `MessageInput`, hidden for AI chats just like those.
- **No schema or migration changes.** Selecting a GIF reuses the existing `imagePreview` state and send pipeline — the GIF URL flows through `sendMessage`/`sendGroupMessage` exactly like an uploaded photo, gets uploaded to Cloudinary server-side, and is stored on the existing `Message.image` field. This means DMs, groups, reactions, replies, and message rendering all work with zero changes to `message.controller.js` or the `Message` model.

## Why this approach

Rather than building a parallel "GIF message" type, this treats a GIF exactly like an image message, since the app already has a complete image-message pipeline (composer → Cloudinary upload → socket emit → render). This kept the diff small and low-risk, per the issue's goal of not disrupting existing messaging functionality.

## Testing performed

- ✅ Trending GIFs load on opening the picker
- ✅ Search by keyword (e.g. "cat") returns relevant, debounced results
- ✅ Preview/selection before sending
- ✅ Sent and rendered correctly (animated) in a 1:1 DM
- ✅ Sent and rendered correctly in a group chat
- ✅ GIF button correctly hidden in the AI assistant chat, matching existing image/file/emoji/mic behavior
- ✅ Pagination via "Load more"
- ✅ Graceful error state when the provider is unreachable/misconfigured
- ✅ Full backend test suite passes with no regressions (`199 passed, 2 skipped, 0 failed`)
- ✅ Frontend build passes (`vite build`)
- ✅ `npm run lint` clean on all new/modified files (no new errors; pre-existing repo-wide warnings unaffected)

**Screenshots:**
*Trending*
<img width="1920" height="859" alt="Screenshot 2026-07-20 170243" src="https://github.com/user-attachments/assets/806456fe-4e3a-4f0c-9082-04a76611cbf7" />
*Cat Search*
<img width="1920" height="866" alt="Screenshot 2026-07-20 171620" src="https://github.com/user-attachments/assets/05422464-5ca0-430f-a6a0-976ccca7bd70" />
*Sent in chat*
<img width="1920" height="866" alt="Screenshot 2026-07-20 170949" src="https://github.com/user-attachments/assets/2b71d0bf-0b00-4d36-88fe-1c527616c667" />
*Sent in group*
<img width="1920" height="866" alt="Screenshot 2026-07-20 171210" src="https://github.com/user-attachments/assets/0b62bd19-b49f-4a65-9f7e-6f7763f40b36" />

## Known limitations

- Requires a `GIPHY_API_KEY` env var to be configured; without it, the picker shows a graceful "not available" message rather than crashing (documented in `.env.example`).
- Currently uses Giphy only (no Tenor fallback), per the issue's "e.g. GIPHY or Tenor" wording — happy to add Tenor as a follow-up if maintainers prefer.
- Rate limit (30 req/min/IP) is a starting point and can be tuned.

Closes #118

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a GIF picker to message composition with trending browsing, search, preview selection, and “Load more” pagination.
  * Integrated GIF selection into the message composer with automatic dismissal when clicking outside the picker.
  * Added protected GIF trending/search endpoints backed by GIPHY, including clear loading, empty, and error states.
  * Improved reliability by preventing outdated search results from overwriting newer ones.
* **Configuration**
  * Added `GIPHY_API_KEY` to the environment configuration example.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->