### PR TITLE
feat(messages): add message forwarding supportFeat/add message forwarding support

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,5 +1,5 @@
 # Database
-MONGODB_URI=your_mongodb_connection_string
+MONGODB_URI=mongodb+srv://Pasochat:UghlsxAF62mfjOWx@pasochat.ano4hvy.mongodb.net/?appName=PasoChat
 
 # Server
 PORT=5001

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,5 +1,5 @@
 # Database
-MONGODB_URI=mongodb+srv://Pasochat:UghlsxAF62mfjOWx@pasochat.ano4hvy.mongodb.net/?appName=PasoChat
+MONGODB_URI=your_mongodb_connection_string
 
 # Server
 PORT=5001

--- a/backend/src/controllers/message.controller.js
+++ b/backend/src/controllers/message.controller.js
@@ -358,6 +358,43 @@ export const sendGroupMessage = async (req, res) => {
   }
 };
 
+export const forwardMessage = async (req, res) => {
+  try {
+    const {messageId, destination} = req.body;
+    const senderId = req.user._id;
+
+    const originalMessage = await Message.findById(messageId);
+
+    if (!originalMessage) {
+      return res.status(404).json({ message: "Original message not found" });
+    }
+
+    const forwardedMessages =[];
+
+    for (const dest of destination) {
+      const newMessageData = await Message.create({
+        senderId,
+        receiverId: dest.receiverId || null,
+        groupId: dest.groupId || null,
+        text: originalMessage.text,
+        image: originalMessage.image,
+        audio: originalMessage.audio,
+        file: originalMessage.file,
+        isForwarded: true,
+        originalMessageId: originalMessage._id,
+      });
+      forwardedMessages.push(newMessageData);
+    }
+    res.status(201).json({ 
+      messages: forwardedMessages,
+      message: "Message forwarded successfully" 
+    });
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ message: "Internal Server Error" });
+  }
+}
+
 export const deleteMessageForMe = async (req, res) => {
   try {
     const { messageId } = req.params;

--- a/backend/src/controllers/message.controller.js
+++ b/backend/src/controllers/message.controller.js
@@ -360,46 +360,70 @@ export const sendGroupMessage = async (req, res) => {
 
 export const forwardMessage = async (req, res) => {
   try {
-    const {messageId, destination} = req.body;
+    // FIX 1: correctly destructure destinations from req.body
+    const { messageId, destinations } = req.body;
     const senderId = req.user._id;
 
     const originalMessage = await Message.findById(messageId);
 
     if (!originalMessage) {
-      return res.status(404).json({ message: "Original message not found" });
+      return res.status(404).json({
+        message: "Original message not found",
+      });
     }
 
-    const forwardedMessages =[];
+    const forwardedMessages = [];
 
-    for (const dest of destination) {
-      const newMessageData = await Message.create({
+    // FIX 2: loop through destinations (not destination)
+    for (const dest of destinations) {
+      const { receiverId, groupId } = dest;
+
+      // Create a safe file object
+      const safeFile =
+        originalMessage.file && typeof originalMessage.file === "object"
+          ? {
+            url: originalMessage.file.url || "",
+            name: originalMessage.file.name || "",
+            type: originalMessage.file.type || "",
+            size: originalMessage.file.size || 0,
+          }
+          : {
+            url: "",
+            name: "",
+            type: "",
+            size: 0,
+          };
+
+      const newMessage = await Message.create({
         senderId,
-        receiverId: dest.receiverId || null,
-        groupId: dest.groupId || null,
+        receiverId: receiverId || null,
+        groupId: groupId || null,
         text: originalMessage.text,
         image: originalMessage.image,
         audio: originalMessage.audio,
-        file: originalMessage.file,
+        file: safeFile,
         isForwarded: true,
         originalMessageId: originalMessage._id,
       });
 
-      if (receiverId){
+      // FIX 3: use the correct variable names for Socket.IO
+      if (receiverId) {
         emitToUser(receiverId.toString(), "newMessage", newMessage);
 
-        emitToUser(senderId.toString(), "messageStatusUpdate",{
-          messageId:newMessage._id,
+        emitToUser(senderId.toString(), "messageStatusUpdate", {
+          messageId: newMessage._id,
           status: "delivered",
         });
-      }else if (groupId){
+      } else if (groupId) {
         io.to(groupId.toString()).emit("newGroupMessage", newMessage);
       }
 
-      forwardedMessages.push(newMessageData);
+      forwardedMessages.push(newMessage);
     }
-    res.status(201).json({ 
+
+    res.status(201).json({
+      message: "Message forwarded successfully",
       messages: forwardedMessages,
-      message: "Message forwarded successfully" 
     });
   } catch (error) {
     console.error(error);

--- a/backend/src/controllers/message.controller.js
+++ b/backend/src/controllers/message.controller.js
@@ -383,6 +383,18 @@ export const forwardMessage = async (req, res) => {
         isForwarded: true,
         originalMessageId: originalMessage._id,
       });
+
+      if (receiverId){
+        emitToUser(receiverId.toString(), "newMessage", newMessage);
+
+        emitToUser(senderId.toString(), "messageStatusUpdate",{
+          messageId:newMessage._id,
+          status: "delivered",
+        });
+      }else if (groupId){
+        io.to(groupId.toString()).emit("newGroupMessage", newMessage);
+      }
+
       forwardedMessages.push(newMessageData);
     }
     res.status(201).json({ 

--- a/backend/src/controllers/message.controller.js
+++ b/backend/src/controllers/message.controller.js
@@ -391,7 +391,7 @@ export const forwardMessage = async (req, res) => {
       if (
         !originalGroup ||
         !originalGroup.members.some(
-          (member) => member.toString() === senderId.toString(),
+          (member) => member.userId.toString() === senderId.toString(),
         )
       ) {
         return res.status(403).json({
@@ -416,7 +416,7 @@ export const forwardMessage = async (req, res) => {
         if (
           !group ||
           !group.members.some(
-            (member) => member.toString() === senderId.toString(),
+            (member) => member.userId.toString() === senderId.toString(),
           )
         ) {
           return res.status(403).json({

--- a/backend/src/controllers/message.controller.js
+++ b/backend/src/controllers/message.controller.js
@@ -364,6 +364,14 @@ export const forwardMessage = async (req, res) => {
     const { messageId, destinations } = req.body;
     const senderId = req.user._id;
 
+    if (!mongoose.Types.ObjectId.isValid(messageId)) {
+      return res.status(400).json({ message: "Invalid message id" });
+    }
+
+    if (!Array.isArray(destinations) || destinations.length === 0) {
+      return res.status(400).json({ message: "Destinations must be a non-empty array" });
+    }
+
     const originalMessage = await Message.findById(messageId);
 
     if (!originalMessage) {
@@ -372,11 +380,50 @@ export const forwardMessage = async (req, res) => {
       });
     }
 
+    const isOriginalPrivateChat =
+      (originalMessage.senderId.toString() === senderId.toString()) ||
+      (originalMessage.receiverId &&
+        originalMessage.receiverId.toString() === senderId.toString());
+
+    if (!isOriginalPrivateChat && originalMessage.groupId) {
+      const originalGroup = await Group.findById(originalMessage.groupId);
+
+      if (
+        !originalGroup ||
+        !originalGroup.members.some(
+          (member) => member.toString() === senderId.toString(),
+        )
+      ) {
+        return res.status(403).json({
+          message: "You are not authorized to forward this message",
+        });
+      }
+    } else if (!isOriginalPrivateChat) {
+      return res.status(403).json({
+        message: "You are not authorized to forward this message",
+      });
+    }
+
     const forwardedMessages = [];
 
     // FIX 2: loop through destinations (not destination)
     for (const dest of destinations) {
       const { receiverId, groupId } = dest;
+
+      if (groupId) {
+        const group = await Group.findById(groupId);
+
+        if (
+          !group ||
+          !group.members.some(
+            (member) => member.toString() === senderId.toString(),
+          )
+        ) {
+          return res.status(403).json({
+            message: "You are not authorized to forward messages to this group",
+          });
+        }
+      }
 
       // Create a safe file object
       const safeFile =

--- a/backend/src/models/message.model.js
+++ b/backend/src/models/message.model.js
@@ -128,6 +128,16 @@ const messageSchema = new mongoose.Schema(
         emoji: String,
       },
     ],
+    isForwarded: {
+      type: Boolean,
+      default: false,
+    },
+    originalMessageId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "Message",
+      default: null,
+      index: true,
+    },
   },
   { timestamps: true },
 );

--- a/backend/src/routes/message.route.js
+++ b/backend/src/routes/message.route.js
@@ -6,6 +6,7 @@ import {
   sendMessage,
   getGroupMessages,
   sendGroupMessage,
+  forwardMessage,
   deleteMessageForMe,
   deleteMessageForEveryone,
   markMessagesSeen,
@@ -29,6 +30,8 @@ router.post("/send/:id", protectRoute, sendMessage);
 
 router.get("/group/:groupId", protectRoute, getGroupMessages);
 router.post("/group/send/:groupId", protectRoute, sendGroupMessage);
+
+router.post("/forward/", protectRoute, forwardMessage);
 
 router.delete("/:messageId/me", protectRoute, deleteMessageForMe);
 router.delete("/:messageId/everyone", protectRoute, deleteMessageForEveryone);

--- a/frontend/src/components/ForwardModal.jsx
+++ b/frontend/src/components/ForwardModal.jsx
@@ -1,0 +1,100 @@
+import { useState } from "react";
+import { axiosInstance } from "../lib/axios";
+import toast from "react-hot-toast";
+
+const ForwardModal = ({ isOpen, onClose, messageId, users = [], groups = [] }) => {
+    const [selected, setSelected] = useState([]);
+    const [loading, setLoading] = useState(false);
+
+    if (!isOpen) return null;
+
+    const toggleSelection = (type, id) => {
+        setSelected((prev) => {
+            const exists = prev.find((item) => item.id === id && item.type === type);
+
+            if (exists) {
+                return prev.filter((item) => !(item.id === id && item.type === type));
+            }
+
+            return [...prev, { type, id }];
+        });
+    };
+
+    const handleForward = async () => {
+        if (selected.length === 0) {
+            toast.error("Select at least one conversation");
+            return;
+        }
+
+        try {
+            setLoading(true);
+
+            const destinations = selected.map((item) =>
+                item.type === "user"
+                    ? { receiverId: item.id }
+                    : { groupId: item.id }
+            );
+
+            await axiosInstance.post("/messages/forward", {
+                messageId,
+                destinations,
+            });
+
+            toast.success("Message forwarded successfully");
+            onClose();
+            setSelected([]);
+        } catch (error) {
+            toast.error(error.response?.data?.message || "Failed to forward message");
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    return (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+            <div className="bg-base-100 w-full max-w-md rounded-2xl p-5 shadow-2xl">
+                <div className="flex items-center justify-between mb-4">
+                    <h2 className="text-lg font-bold">Forward Message</h2>
+                    <button onClick={onClose} className="text-xl">×</button>
+                </div>
+
+                <div className="max-h-80 overflow-y-auto space-y-2">
+                    {users.map((user) => (
+                        <label key={user._id} className="flex items-center gap-3 p-3 rounded-lg hover:bg-base-200 cursor-pointer">
+                            <input
+                                type="checkbox"
+                                checked={selected.some((s) => s.id === user._id && s.type === "user")}
+                                onChange={() => toggleSelection("user", user._id)}
+                            />
+                            <img src={user.profilePic || "/avatar.png"} alt="" className="w-10 h-10 rounded-full" />
+                            <span className="font-medium">{user.fullName}</span>
+                        </label>
+                    ))}
+
+                    {groups.map((group) => (
+                        <label key={group._id} className="flex items-center gap-3 p-3 rounded-lg hover:bg-base-200 cursor-pointer">
+                            <input
+                                type="checkbox"
+                                checked={selected.some((s) => s.id === group._id && s.type === "group")}
+                                onChange={() => toggleSelection("group", group._id)}
+                            />
+                            <div className="w-10 h-10 rounded-full bg-primary/20 flex items-center justify-center">
+                                <span className="font-bold">{group.name?.[0] || "G"}</span>
+                            </div>
+                            <span className="font-medium">{group.name}</span>
+                        </label>
+                    ))}
+                </div>
+
+                <div className="flex justify-end gap-3 mt-5">
+                    <button onClick={onClose} className="btn btn-ghost">Cancel</button>
+                    <button onClick={handleForward} disabled={loading} className="btn btn-primary">
+                        {loading ? "Forwarding..." : "Forward"}
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default ForwardModal;

--- a/frontend/src/components/MessageBubble.jsx
+++ b/frontend/src/components/MessageBubble.jsx
@@ -300,6 +300,22 @@ const MessageBubble = ({ message, sender, isMe, chatId }) => {
                 transition={{ repeat: Infinity, duration: 3 }}
                 className={`relative px-4 py-2.5 shadow-sm transition-all duration-300 rounded-2xl
                 ${highlightedMessageId === message._id ? "ring-2 ring-primary ring-offset-2 bg-primary/10" : ""}
+                ${message.isForwarded && (
+                    <div className={`relative px-4 py-2.5 shadow-sm transition-all duration-300 rounded-2xl
+                        ${highlightedMessageId === message._id ? "ring-2 ring-primary ring-offset-2 bg-primary/10" : ""}
+                        ${message.deletedForEveryone
+                        ? "bg-base-200/50 border border-base-300 text-base-content/40 italic"
+                        : isMe
+                          ? "bg-primary text-primary-content rounded-tr-none shadow-md"
+                          : isAI
+                            ? "bg-base-100 border-2 border-primary/20 text-base-content rounded-tl-none shadow-lg shadow-primary/5"
+                            : "ƒbg-base-100 border border-base-200 text-base-content rounded-tl-none shadow-sm"
+                      }
+                    `}>
+                      <Forward size={12} className="opacity-70" />
+                      <span>Forwarded</span>
+                    </div>
+                  )}
                 ${message.deletedForEveryone ? "bg-base-200/50 border border-base-300 text-base-content/40 italic" :
                     isMe ? "bg-primary text-primary-content rounded-tr-none shadow-md" :
                       isAI ? "bg-base-100 border-2 border-primary/20 text-base-content rounded-tl-none shadow-lg shadow-primary/5" :
@@ -312,6 +328,12 @@ const MessageBubble = ({ message, sender, isMe, chatId }) => {
                   </div>
                 ) : (
                   <>
+                    {message.isForwarded && (
+                      <div className={`mb-1.5 flex items-center gap-1.5 text-[12px] text-base-content/70 ${isMe ? "text-[#D1DBFF]" : "text-[#4A00FF]"}`}>
+                        <Forward size={12} />
+                        <span>Forwarded</span>
+                      </div>
+                    )}
                     {isAI && (
                       <div className="absolute -top-2 -left-2 bg-primary text-primary-content p-1 rounded-full shadow-lg scale-75">
                         <Sparkles size={10} fill="currentColor" />

--- a/frontend/src/components/MessageBubble.jsx
+++ b/frontend/src/components/MessageBubble.jsx
@@ -11,6 +11,7 @@ import {
   CheckCheck,
   Sparkles,
   Reply,
+  forward,
 } from "lucide-react";
 import { motion, AnimatePresence } from "framer-motion";
 import { useChatStore } from "../store/useChatStore";
@@ -111,6 +112,11 @@ const MessageBubble = ({ message, sender, isMe, chatId }) => {
       setOpen(false);
     }
   };
+
+  const handleForward = () => {
+    console.log("Forward message", message._id);
+    setOpen(false);
+  }
 
   return (
     <motion.div
@@ -247,6 +253,13 @@ const MessageBubble = ({ message, sender, isMe, chatId }) => {
                         <Reply size={16} className="opacity-50" />
                         <span>Reply</span>
                       </button>
+
+                      <button onClick={handleForward}
+                        className="flex w-full items-center gap-3 px-4 py-3 text-sm hover:bg-base-200">
+                          <Forward size={16} className="opacity-50" />
+                          <span>Forward</span>
+                      </button>
+
                       {!isMe && !message.deletedForEveryone && (
                         <button onClick={handleReport} className="flex w-full items-center gap-3 px-4 py-3 text-sm hover:bg-warning/10 text-warning border-t border-base-200">
                           <ShieldAlert size={16} />

--- a/frontend/src/components/MessageBubble.jsx
+++ b/frontend/src/components/MessageBubble.jsx
@@ -11,7 +11,7 @@ import {
   CheckCheck,
   Sparkles,
   Reply,
-  forward,
+  Forward,
 } from "lucide-react";
 import { motion, AnimatePresence } from "framer-motion";
 import { useChatStore } from "../store/useChatStore";
@@ -21,6 +21,7 @@ import { formatMessageTime } from "../lib/utils";
 import toast from "react-hot-toast";
 import { axiosInstance } from "../lib/axios";
 import { useAuthStore } from "../store/useAuthStore";
+import ForwardModal from "./ForwardModal";
 
 const REACTIONS = ["👍", "❤️", "😂", "😮", "😢", "🔥"];
 
@@ -30,7 +31,8 @@ const MessageBubble = ({ message, sender, isMe, chatId }) => {
   const [emojiPosition, setEmojiPosition] = useState({ top: 0, left: 0 });
   const [menuPosition, setMenuPosition] = useState({ top: 0, left: 0 });
   const [isMobile, setIsMobile] = useState(typeof window !== "undefined" ? window.innerWidth < 640 : false);
-  
+  const [showForwardModal, setShowForwardModal] = useState(false);
+
   const menuRef = useRef(null);
   const emojiRef = useRef(null);
 
@@ -69,15 +71,15 @@ const MessageBubble = ({ message, sender, isMe, chatId }) => {
   useEffect(() => {
     const handleResize = () => setIsMobile(window.innerWidth < 640);
     window.addEventListener("resize", handleResize);
-    
+
     const handleClickOutside = (event) => {
       if (menuRef.current && !menuRef.current.contains(event.target)) setOpen(false);
       if (emojiRef.current && !emojiRef.current.contains(event.target)) setShowEmojis(false);
     };
-    
+
     document.addEventListener("mousedown", handleClickOutside);
     document.addEventListener("touchstart", handleClickOutside);
-    
+
     return () => {
       window.removeEventListener("resize", handleResize);
       document.removeEventListener("mousedown", handleClickOutside);
@@ -114,283 +116,293 @@ const MessageBubble = ({ message, sender, isMe, chatId }) => {
   };
 
   const handleForward = () => {
-    console.log("Forward message", message._id);
+    setShowForwardModal(true);
     setOpen(false);
   }
 
   return (
-    <motion.div
-      initial={isAI ? { opacity: 0, y: 10, scale: 0.95 } : false}
-      animate={{ opacity: 1, y: 0, scale: 1 }}
-      transition={{ duration: 0.4, ease: "easeOut" }}
-      id={`msg-${message._id}`}
-      className={`chat ${isMe ? "chat-end" : "chat-start"} group mb-4 sm:mb-6 px-2 sm:px-4 relative`}
-    >
-      <div className="chat-image avatar self-end mb-1">
-        <div className={`h-8 w-8 rounded-full shadow-sm overflow-hidden ring-1 flex items-center justify-center ${isAI ? "ring-primary animate-pulse" : "ring-base-300"}`}>
-          <img
-            src={sender?.profilePic || "/avatar.png"}
-            alt="avatar"
-            className="h-full w-full object-cover rounded-full"
-            onError={(e) => { e.currentTarget.src = "/avatar.png"; }}
-          />
+    <>
+      <motion.div
+        initial={isAI ? { opacity: 0, y: 10, scale: 0.95 } : false}
+        animate={{ opacity: 1, y: 0, scale: 1 }}
+        transition={{ duration: 0.4, ease: "easeOut" }}
+        id={`msg-${message._id}`}
+        className={`chat ${isMe ? "chat-end" : "chat-start"} group mb-4 sm:mb-6 px-2 sm:px-4 relative`}
+      >
+        <div className="chat-image avatar self-end mb-1">
+          <div className={`h-8 w-8 rounded-full shadow-sm overflow-hidden ring-1 flex items-center justify-center ${isAI ? "ring-primary animate-pulse" : "ring-base-300"}`}>
+            <img
+              src={sender?.profilePic || "/avatar.png"}
+              alt="avatar"
+              className="h-full w-full object-cover rounded-full"
+              onError={(e) => { e.currentTarget.src = "/avatar.png"; }}
+            />
+          </div>
         </div>
-      </div>
 
-      <div className={`flex flex-col max-w-[85%] sm:max-w-[70%] ${isMe ? "items-end" : "items-start"}`}>
-        <div className={`flex items-center gap-1 sm:gap-2 ${isMe ? "flex-row" : "flex-row-reverse"}`}>
-          
-          <div className="flex items-center gap-0.5 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 transition-opacity duration-200">
-            <div className="relative" ref={emojiRef}>
-              <button
-                onClick={(e) => {
-                  e.stopPropagation();
-                  if (isMobile) {
-                    setEmojiPosition({ top: window.innerHeight / 2, left: window.innerWidth / 2 - 150 });
-                  } else {
-                    const rect = e.currentTarget.getBoundingClientRect();
-                    // 2. Safe Desktop Position (Clamping)
-                    setEmojiPosition({ 
-                      top: rect.top - 60, 
-                      left: Math.min(Math.max(rect.left + rect.width / 2, 120), window.innerWidth - 120) 
-                    });
-                  }
-                  setShowEmojis((prev) => !prev);
-                  setOpen(false);
-                }}
-                className={`p-2 rounded-full hover:bg-base-200 transition-colors ${showEmojis ? "text-primary bg-base-200" : "text-base-content/40"}`}
-              >
-                <SmilePlus size={18} />
-              </button>
+        <div className={`flex flex-col max-w-[85%] sm:max-w-[70%] ${isMe ? "items-end" : "items-start"}`}>
+          <div className={`flex items-center gap-1 sm:gap-2 ${isMe ? "flex-row" : "flex-row-reverse"}`}>
 
-              <AnimatePresence>
-                {showEmojis && (
-                  <>
-                    {isMobile && <div className="fixed inset-0 bg-black/20 z-[9998]" onClick={() => setShowEmojis(false)} />}
-                    <motion.div
-                      initial={{ opacity: 0, scale: 0.8, y: isMobile ? -50 : 10 }}
-                      animate={{ opacity: 1, scale: 1, y: isMobile ? -50 : 0 }}
-                      exit={{ opacity: 0, scale: 0.8, y: isMobile ? -50 : 10 }}
-                      className="fixed z-[9999] bg-base-100 border border-base-300 rounded-2xl px-3 py-2 shadow-xl flex items-center gap-2 sm:gap-3"
-                      style={{
-                        top: emojiPosition.top,
-                        left: emojiPosition.left,
-                        transform: "translate(-50%, -50%)",
-                      }}
-                    >
-                      {REACTIONS.map((emoji) => (
-                        <button
-                          key={emoji}
-                          onClick={async () => {
-                            try {
-                              await axiosInstance.post(`/messages/react/${message._id}`, { emoji });
-                            } catch (err) {
-                              toast.error("Failed to react");
-                            }
-                            setShowEmojis(false);
-                          }}
-                          className="text-2xl hover:scale-125 active:scale-90 transition-transform p-1"
-                        >
-                          {emoji}
+            <div className="flex items-center gap-0.5 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 transition-opacity duration-200">
+              <div className="relative" ref={emojiRef}>
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    if (isMobile) {
+                      setEmojiPosition({ top: window.innerHeight / 2, left: window.innerWidth / 2 - 150 });
+                    } else {
+                      const rect = e.currentTarget.getBoundingClientRect();
+                      // 2. Safe Desktop Position (Clamping)
+                      setEmojiPosition({
+                        top: rect.top - 60,
+                        left: Math.min(Math.max(rect.left + rect.width / 2, 120), window.innerWidth - 120)
+                      });
+                    }
+                    setShowEmojis((prev) => !prev);
+                    setOpen(false);
+                  }}
+                  className={`p-2 rounded-full hover:bg-base-200 transition-colors ${showEmojis ? "text-primary bg-base-200" : "text-base-content/40"}`}
+                >
+                  <SmilePlus size={18} />
+                </button>
+
+                <AnimatePresence>
+                  {showEmojis && (
+                    <>
+                      {isMobile && <div className="fixed inset-0 bg-black/20 z-[9998]" onClick={() => setShowEmojis(false)} />}
+                      <motion.div
+                        initial={{ opacity: 0, scale: 0.8, y: isMobile ? -50 : 10 }}
+                        animate={{ opacity: 1, scale: 1, y: isMobile ? -50 : 0 }}
+                        exit={{ opacity: 0, scale: 0.8, y: isMobile ? -50 : 10 }}
+                        className="fixed z-[9999] bg-base-100 border border-base-300 rounded-2xl px-3 py-2 shadow-xl flex items-center gap-2 sm:gap-3"
+                        style={{
+                          top: emojiPosition.top,
+                          left: emojiPosition.left,
+                          transform: "translate(-50%, -50%)",
+                        }}
+                      >
+                        {REACTIONS.map((emoji) => (
+                          <button
+                            key={emoji}
+                            onClick={async () => {
+                              try {
+                                await axiosInstance.post(`/messages/react/${message._id}`, { emoji });
+                              } catch (err) {
+                                toast.error("Failed to react");
+                              }
+                              setShowEmojis(false);
+                            }}
+                            className="text-2xl hover:scale-125 active:scale-90 transition-transform p-1"
+                          >
+                            {emoji}
+                          </button>
+                        ))}
+                      </motion.div>
+                    </>
+                  )}
+                </AnimatePresence>
+              </div>
+
+              <div className="relative" ref={menuRef}>
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    if (isMobile) {
+                      setMenuPosition({ top: window.innerHeight / 2, left: window.innerWidth / 2 - 105 });
+                    } else {
+                      const rect = e.currentTarget.getBoundingClientRect();
+                      // Clamping menu position
+                      setMenuPosition({
+                        top: rect.top,
+                        left: Math.min(Math.max(rect.left, 100), window.innerWidth - 100)
+                      });
+                    }
+                    setOpen((prev) => !prev);
+                    setShowEmojis(false);
+                  }}
+                  className={`p-2 rounded-full hover:bg-base-200 transition-colors ${open ? "text-primary bg-base-200" : "text-base-content/40"}`}
+                >
+                  <MoreVertical size={18} />
+                </button>
+
+                <AnimatePresence>
+                  {open && (
+                    <>
+                      {isMobile && <div className="fixed inset-0 bg-black/20 z-[9998]" onClick={() => setOpen(false)} />}
+                      <motion.div
+                        initial={{ opacity: 0, scale: 0.95, y: isMobile ? -50 : 10 }}
+                        animate={{ opacity: 1, scale: 1, y: isMobile ? -50 : 0 }}
+                        exit={{ opacity: 0, scale: 0.95, y: isMobile ? -50 : 10 }}
+                        className="fixed z-[9999] w-56 bg-base-100 border border-base-300 rounded-2xl shadow-2xl overflow-hidden py-1"
+                        style={{
+                          top: menuPosition.top,
+                          left: menuPosition.left,
+                          transform: isMobile ? "translate(-50%, -50%)" : "translateX(-100%)",
+                        }}
+                      >
+                        {!message.deletedForEveryone && (
+                          <button onClick={() => { togglePin(chatId, message._id); setOpen(false); }} className="flex w-full items-center gap-3 px-4 py-3 text-sm hover:bg-base-200">
+                            <Pin size={16} className={isPinned ? "text-warning fill-warning" : "opacity-50"} />
+                            <span>{isPinned ? "Unpin" : "Pin Message"}</span>
+                          </button>
+                        )}
+                        {message.text && (
+                          <button onClick={handleCopyText} className="flex w-full items-center gap-3 px-4 py-3 text-sm hover:bg-base-200">
+                            <Copy size={16} className="opacity-50" />
+                            <span>Copy Text</span>
+                          </button>
+                        )}
+                        <button onClick={() => { setReplyingTo(message); setOpen(false); }} className="flex w-full items-center gap-3 px-4 py-3 text-sm hover:bg-base-200">
+                          <Reply size={16} className="opacity-50" />
+                          <span>Reply</span>
                         </button>
-                      ))}
-                    </motion.div>
-                  </>
-                )}
-              </AnimatePresence>
-            </div>
 
-            <div className="relative" ref={menuRef}>
-              <button
-                onClick={(e) => {
-                  e.stopPropagation();
-                  if (isMobile) {
-                    setMenuPosition({ top: window.innerHeight / 2, left: window.innerWidth / 2 - 105 });
-                  } else {
-                    const rect = e.currentTarget.getBoundingClientRect();
-                    // Clamping menu position
-                    setMenuPosition({ 
-                      top: rect.top, 
-                      left: Math.min(Math.max(rect.left, 100), window.innerWidth - 100)
-                    });
-                  }
-                  setOpen((prev) => !prev);
-                  setShowEmojis(false);
-                }}
-                className={`p-2 rounded-full hover:bg-base-200 transition-colors ${open ? "text-primary bg-base-200" : "text-base-content/40"}`}
-              >
-                <MoreVertical size={18} />
-              </button>
-
-              <AnimatePresence>
-                {open && (
-                  <>
-                    {isMobile && <div className="fixed inset-0 bg-black/20 z-[9998]" onClick={() => setOpen(false)} />}
-                    <motion.div
-                      initial={{ opacity: 0, scale: 0.95, y: isMobile ? -50 : 10 }}
-                      animate={{ opacity: 1, scale: 1, y: isMobile ? -50 : 0 }}
-                      exit={{ opacity: 0, scale: 0.95, y: isMobile ? -50 : 10 }}
-                      className="fixed z-[9999] w-56 bg-base-100 border border-base-300 rounded-2xl shadow-2xl overflow-hidden py-1"
-                      style={{
-                        top: menuPosition.top,
-                        left: menuPosition.left,
-                        transform: isMobile ? "translate(-50%, -50%)" : "translateX(-100%)",
-                      }}
-                    >
-                      {!message.deletedForEveryone && (
-                        <button onClick={() => { togglePin(chatId, message._id); setOpen(false); }} className="flex w-full items-center gap-3 px-4 py-3 text-sm hover:bg-base-200">
-                          <Pin size={16} className={isPinned ? "text-warning fill-warning" : "opacity-50"} />
-                          <span>{isPinned ? "Unpin" : "Pin Message"}</span>
-                        </button>
-                      )}
-                      {message.text && (
-                        <button onClick={handleCopyText} className="flex w-full items-center gap-3 px-4 py-3 text-sm hover:bg-base-200">
-                          <Copy size={16} className="opacity-50" />
-                          <span>Copy Text</span>
-                        </button>
-                      )}
-                      <button onClick={() => { setReplyingTo(message); setOpen(false); }} className="flex w-full items-center gap-3 px-4 py-3 text-sm hover:bg-base-200">
-                        <Reply size={16} className="opacity-50" />
-                        <span>Reply</span>
-                      </button>
-
-                      <button onClick={handleForward}
-                        className="flex w-full items-center gap-3 px-4 py-3 text-sm hover:bg-base-200">
+                        <button onClick={handleForward}
+                          className="flex w-full items-center gap-3 px-4 py-3 text-sm hover:bg-base-200">
                           <Forward size={16} className="opacity-50" />
                           <span>Forward</span>
-                      </button>
-
-                      {!isMe && !message.deletedForEveryone && (
-                        <button onClick={handleReport} className="flex w-full items-center gap-3 px-4 py-3 text-sm hover:bg-warning/10 text-warning border-t border-base-200">
-                          <ShieldAlert size={16} />
-                          <span>Report</span>
                         </button>
-                      )}
-                      <button onClick={() => { deleteMessageForMe(message._id); setOpen(false); }} className="flex w-full items-center gap-3 px-4 py-3 text-sm hover:bg-base-200 border-t border-base-200">
-                        <Trash size={16} className="opacity-50" />
-                        <span>Delete for me</span>
-                      </button>
-                      {canDeleteForEveryone && (
-                        <button onClick={() => { deleteMessageForEveryone(message._id); setOpen(false); }} className="flex w-full items-center gap-3 px-4 py-3 text-sm text-error hover:bg-error/10 border-t border-base-200 font-medium">
-                          <Trash2 size={16} />
-                          <span>Delete for all</span>
-                        </button>
-                      )}
-                    </motion.div>
-                  </>
-                )}
-              </AnimatePresence>
-            </div>
-          </div>
 
-          <div className="relative">
-            {isPinned && (
-              <div className={`absolute -top-3 ${isMe ? "-left-1" : "-right-1"} z-20`}>
-                <Pin size={14} className="text-warning fill-warning rotate-45 shadow-sm" />
+                        {!isMe && !message.deletedForEveryone && (
+                          <button onClick={handleReport} className="flex w-full items-center gap-3 px-4 py-3 text-sm hover:bg-warning/10 text-warning border-t border-base-200">
+                            <ShieldAlert size={16} />
+                            <span>Report</span>
+                          </button>
+                        )}
+                        <button onClick={() => { deleteMessageForMe(message._id); setOpen(false); }} className="flex w-full items-center gap-3 px-4 py-3 text-sm hover:bg-base-200 border-t border-base-200">
+                          <Trash size={16} className="opacity-50" />
+                          <span>Delete for me</span>
+                        </button>
+                        {canDeleteForEveryone && (
+                          <button onClick={() => { deleteMessageForEveryone(message._id); setOpen(false); }} className="flex w-full items-center gap-3 px-4 py-3 text-sm text-error hover:bg-error/10 border-t border-base-200 font-medium">
+                            <Trash2 size={16} />
+                            <span>Delete for all</span>
+                          </button>
+                        )}
+                      </motion.div>
+                    </>
+                  )}
+                </AnimatePresence>
               </div>
-            )}
+            </div>
 
-            <motion.div
-              animate={isAI ? { boxShadow: ["0px 0px 0px rgba(59, 130, 246, 0)", "0px 0px 12px rgba(59, 130, 246, 0.2)", "0px 0px 0px rgba(59, 130, 246, 0)"] } : {}}
-              transition={{ repeat: Infinity, duration: 3 }}
-              className={`relative px-4 py-2.5 shadow-sm transition-all duration-300 rounded-2xl
-                ${highlightedMessageId === message._id ? "ring-2 ring-primary ring-offset-2 bg-primary/10" : ""}
-                ${message.deletedForEveryone ? "bg-base-200/50 border border-base-300 text-base-content/40 italic" : 
-                  isMe ? "bg-primary text-primary-content rounded-tr-none shadow-md" : 
-                  isAI ? "bg-base-100 border-2 border-primary/20 text-base-content rounded-tl-none shadow-lg shadow-primary/5" : 
-                  "bg-base-100 border border-base-200 text-base-content rounded-tl-none shadow-sm"}
-              `}
-            >
-              {message.deletedForEveryone ? (
-                <div className="flex items-center gap-2 text-[13px]">
-                  <ShieldAlert size={14} /> <span>Message deleted</span>
+            <div className="relative">
+              {isPinned && (
+                <div className={`absolute -top-3 ${isMe ? "-left-1" : "-right-1"} z-20`}>
+                  <Pin size={14} className="text-warning fill-warning rotate-45 shadow-sm" />
                 </div>
-              ) : (
-                <>
-                  {isAI && (
-                    <div className="absolute -top-2 -left-2 bg-primary text-primary-content p-1 rounded-full shadow-lg scale-75">
-                      <Sparkles size={10} fill="currentColor" />
-                    </div>
-                  )}
+              )}
 
-                  {message.replyTo && (
-                    <div
-                      onClick={() => {
-                        const id = message.replyTo._id;
-                        setHighlightedMessage(id);
-                        document.getElementById(`msg-${id}`)?.scrollIntoView({ behavior: "smooth", block: "center" });
-                        setTimeout(() => setHighlightedMessage(null), 1200);
-                      }}
-                      className="mb-1.5 px-2 py-1.5 rounded-lg bg-black/5 text-[12px] border-l-4 border-primary cursor-pointer hover:bg-black/10 transition"
-                    >
-                      <div className="font-bold text-primary truncate">{message.replyTo.senderId?.fullName || "User"}</div>
-                      <div className="truncate opacity-80">{message.replyTo.text || "Media message"}</div>
-                    </div>
-                  )}
+              <motion.div
+                animate={isAI ? { boxShadow: ["0px 0px 0px rgba(59, 130, 246, 0)", "0px 0px 12px rgba(59, 130, 246, 0.2)", "0px 0px 0px rgba(59, 130, 246, 0)"] } : {}}
+                transition={{ repeat: Infinity, duration: 3 }}
+                className={`relative px-4 py-2.5 shadow-sm transition-all duration-300 rounded-2xl
+                ${highlightedMessageId === message._id ? "ring-2 ring-primary ring-offset-2 bg-primary/10" : ""}
+                ${message.deletedForEveryone ? "bg-base-200/50 border border-base-300 text-base-content/40 italic" :
+                    isMe ? "bg-primary text-primary-content rounded-tr-none shadow-md" :
+                      isAI ? "bg-base-100 border-2 border-primary/20 text-base-content rounded-tl-none shadow-lg shadow-primary/5" :
+                        "bg-base-100 border border-base-200 text-base-content rounded-tl-none shadow-sm"}
+              `}
+              >
+                {message.deletedForEveryone ? (
+                  <div className="flex items-center gap-2 text-[13px]">
+                    <ShieldAlert size={14} /> <span>Message deleted</span>
+                  </div>
+                ) : (
+                  <>
+                    {isAI && (
+                      <div className="absolute -top-2 -left-2 bg-primary text-primary-content p-1 rounded-full shadow-lg scale-75">
+                        <Sparkles size={10} fill="currentColor" />
+                      </div>
+                    )}
 
-                  {(message.image || message.audio || message.file?.url) && (
-                    <div className="flex flex-col gap-2 mb-2">
-                      {message.image && <img src={message.image} className="rounded-xl max-w-full max-h-80 object-cover border border-black/5" alt="attachment" />}
-                      {message.audio && <AudioMessage audioUrl={message.audio} isMe={isMe} />}
-                      {message.file?.url && <FileMessage file={message.file} />}
-                    </div>
-                  )}
+                    {message.replyTo && (
+                      <div
+                        onClick={() => {
+                          const id = message.replyTo._id;
+                          setHighlightedMessage(id);
+                          document.getElementById(`msg-${id}`)?.scrollIntoView({ behavior: "smooth", block: "center" });
+                          setTimeout(() => setHighlightedMessage(null), 1200);
+                        }}
+                        className="mb-1.5 px-2 py-1.5 rounded-lg bg-black/5 text-[12px] border-l-4 border-primary cursor-pointer hover:bg-black/10 transition"
+                      >
+                        <div className="font-bold text-primary truncate">{message.replyTo.senderId?.fullName || "User"}</div>
+                        <div className="truncate opacity-80">{message.replyTo.text || "Media message"}</div>
+                      </div>
+                    )}
 
-                  {!message.deletedForEveryone && (message.toxic || message.spam) && (
-                    <div className="mb-2 flex gap-2 flex-wrap">
-                      {message.toxic && (
-                        <div className="flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-red-500/10 text-red-500 border border-red-500/20">
-                          <ShieldAlert size={12} />
-                          <span className="text-[10px] font-bold uppercase tracking-tighter">Toxic</span>
-                        </div>
-                      )}
-                      {message.spam && (
-                        <div className="flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-amber-500/10 text-amber-500 border border-amber-500/20">
-                          <ShieldAlert size={12} />
-                          <span className="text-[10px] font-bold uppercase tracking-tighter">Spam</span>
-                        </div>
-                      )}
-                    </div>
-                  )}
+                    {(message.image || message.audio || message.file?.url) && (
+                      <div className="flex flex-col gap-2 mb-2">
+                        {message.image && <img src={message.image} className="rounded-xl max-w-full max-h-80 object-cover border border-black/5" alt="attachment" />}
+                        {message.audio && <AudioMessage audioUrl={message.audio} isMe={isMe} />}
+                        {message.file?.url && <FileMessage file={message.file} />}
+                      </div>
+                    )}
 
-                  {message.text && (
-                    <p className="text-[15px] sm:text-[14.5px] leading-relaxed whitespace-pre-wrap break-words">
-                      {Array.isArray(highlightedText)
-                        ? highlightedText.map((part, i) =>
+                    {!message.deletedForEveryone && (message.toxic || message.spam) && (
+                      <div className="mb-2 flex gap-2 flex-wrap">
+                        {message.toxic && (
+                          <div className="flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-red-500/10 text-red-500 border border-red-500/20">
+                            <ShieldAlert size={12} />
+                            <span className="text-[10px] font-bold uppercase tracking-tighter">Toxic</span>
+                          </div>
+                        )}
+                        {message.spam && (
+                          <div className="flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-amber-500/10 text-amber-500 border border-amber-500/20">
+                            <ShieldAlert size={12} />
+                            <span className="text-[10px] font-bold uppercase tracking-tighter">Spam</span>
+                          </div>
+                        )}
+                      </div>
+                    )}
+
+                    {message.text && (
+                      <p className="text-[15px] sm:text-[14.5px] leading-relaxed whitespace-pre-wrap break-words">
+                        {Array.isArray(highlightedText)
+                          ? highlightedText.map((part, i) =>
                             part.toLowerCase() === searchQuery?.toLowerCase() ? (
                               <mark key={i} className="bg-yellow-300 text-black px-0.5 rounded-sm">{part}</mark>
                             ) : (
                               <span key={i}>{part}</span>
                             )
                           )
-                        : highlightedText}
-                    </p>
-                  )}
-                </>
-              )}
+                          : highlightedText}
+                      </p>
+                    )}
+                  </>
+                )}
 
-              {message.reactions?.length > 0 && (
-                <motion.div
-                  initial={{ scale: 0 }}
-                  animate={{ scale: 1 }}
-                  className={`absolute -bottom-3.5 ${isMe ? "left-0" : "right-0"} flex items-center gap-1 bg-base-100 border border-base-300 rounded-full px-1.5 py-0.5 shadow-md z-10`}
-                >
-                  {message.reactions.map((r, i) => (
-                    <span key={i} className="text-[12px] leading-none">{r.emoji}</span>
-                  ))}
-                </motion.div>
-              )}
-            </motion.div>
+                {message.reactions?.length > 0 && (
+                  <motion.div
+                    initial={{ scale: 0 }}
+                    animate={{ scale: 1 }}
+                    className={`absolute -bottom-3.5 ${isMe ? "left-0" : "right-0"} flex items-center gap-1 bg-base-100 border border-base-300 rounded-full px-1.5 py-0.5 shadow-md z-10`}
+                  >
+                    {message.reactions.map((r, i) => (
+                      <span key={i} className="text-[12px] leading-none">{r.emoji}</span>
+                    ))}
+                  </motion.div>
+                )}
+              </motion.div>
+            </div>
+          </div>
+
+          <div className={`mt-2 flex items-center gap-1.5 text-[10px] font-bold opacity-60 ${isMe ? "mr-1" : "ml-1"}`}>
+            {isAI && <span className="text-primary uppercase tracking-widest">Meta AI</span>}
+            <span>{formatMessageTime(message.createdAt)}</span>
+            {renderStatusTick()}
           </div>
         </div>
+      </motion.div>
 
-        <div className={`mt-2 flex items-center gap-1.5 text-[10px] font-bold opacity-60 ${isMe ? "mr-1" : "ml-1"}`}>
-          {isAI && <span className="text-primary uppercase tracking-widest">Meta AI</span>}
-          <span>{formatMessageTime(message.createdAt)}</span>
-          {renderStatusTick()}
-        </div>
-      </div>
-    </motion.div>
+      <ForwardModal
+        isOpen={showForwardModal}
+        onClose={() => setShowForwardModal(false)}
+        messageId={message._id}
+        users={[]}
+        groups={[]}
+      />
+    </>
   );
 };
 

--- a/frontend/src/components/MessageBubble.jsx
+++ b/frontend/src/components/MessageBubble.jsx
@@ -296,31 +296,29 @@ const MessageBubble = ({ message, sender, isMe, chatId }) => {
               )}
 
               <motion.div
-                animate={isAI ? { boxShadow: ["0px 0px 0px rgba(59, 130, 246, 0)", "0px 0px 12px rgba(59, 130, 246, 0.2)", "0px 0px 0px rgba(59, 130, 246, 0)"] } : {}}
+                animate={
+                  isAI
+                    ? {
+                      boxShadow: [
+                        "0px 0px 0px rgba(59, 130, 246, 0)",
+                        "0px 0px 12px rgba(59, 130, 246, 0.2)",
+                        "0px 0px 0px rgba(59, 130, 246, 0)",
+                      ],
+                    }
+                    : {}
+                }
                 transition={{ repeat: Infinity, duration: 3 }}
                 className={`relative px-4 py-2.5 shadow-sm transition-all duration-300 rounded-2xl
-                ${highlightedMessageId === message._id ? "ring-2 ring-primary ring-offset-2 bg-primary/10" : ""}
-                ${message.isForwarded && (
-                    <div className={`relative px-4 py-2.5 shadow-sm transition-all duration-300 rounded-2xl
-                        ${highlightedMessageId === message._id ? "ring-2 ring-primary ring-offset-2 bg-primary/10" : ""}
-                        ${message.deletedForEveryone
-                        ? "bg-base-200/50 border border-base-300 text-base-content/40 italic"
-                        : isMe
-                          ? "bg-primary text-primary-content rounded-tr-none shadow-md"
-                          : isAI
-                            ? "bg-base-100 border-2 border-primary/20 text-base-content rounded-tl-none shadow-lg shadow-primary/5"
-                            : "ƒbg-base-100 border border-base-200 text-base-content rounded-tl-none shadow-sm"
-                      }
-                    `}>
-                      <Forward size={12} className="opacity-70" />
-                      <span>Forwarded</span>
-                    </div>
-                  )}
-                ${message.deletedForEveryone ? "bg-base-200/50 border border-base-300 text-base-content/40 italic" :
-                    isMe ? "bg-primary text-primary-content rounded-tr-none shadow-md" :
-                      isAI ? "bg-base-100 border-2 border-primary/20 text-base-content rounded-tl-none shadow-lg shadow-primary/5" :
-                        "bg-base-100 border border-base-200 text-base-content rounded-tl-none shadow-sm"}
-              `}
+                    ${highlightedMessageId === message._id ? "ring-2 ring-primary ring-offset-2 bg-primary/10" : ""}
+                    ${message.deletedForEveryone
+                    ? "bg-base-200/50 border border-base-300 text-base-content/40 italic"
+                    : isMe
+                      ? "bg-primary text-primary-content rounded-tr-none shadow-md"
+                      : isAI
+                        ? "bg-base-100 border-2 border-primary/20 text-base-content rounded-tl-none shadow-lg shadow-primary/5"
+                        : "bg-base-100 border border-base-200 text-base-content rounded-tl-none shadow-sm"
+                  }
+                `}
               >
                 {message.deletedForEveryone ? (
                   <div className="flex items-center gap-2 text-[13px]">
@@ -329,11 +327,15 @@ const MessageBubble = ({ message, sender, isMe, chatId }) => {
                 ) : (
                   <>
                     {message.isForwarded && (
-                      <div className={`mb-1.5 flex items-center gap-1.5 text-[12px] text-base-content/70 ${isMe ? "text-[#D1DBFF]" : "text-[#4A00FF]"}`}>
+                      <div
+                        className={`mb-1.5 flex items-center gap-1.5 text-[12px] ${isMe ? "text-[#D1DBFF]" : "text-[#4A00FF]"
+                          }`}
+                      >
                         <Forward size={12} />
                         <span>Forwarded</span>
                       </div>
                     )}
+
                     {isAI && (
                       <div className="absolute -top-2 -left-2 bg-primary text-primary-content p-1 rounded-full shadow-lg scale-75">
                         <Sparkles size={10} fill="currentColor" />

--- a/frontend/src/components/MessageBubble.jsx
+++ b/frontend/src/components/MessageBubble.jsx
@@ -45,6 +45,8 @@ const MessageBubble = ({ message, sender, isMe, chatId }) => {
     setHighlightedMessage,
     highlightedMessageId,
     searchQuery,
+    users,
+    groups,
   } = useChatStore();
 
   const authUser = useAuthStore((state) => state.authUser);
@@ -399,8 +401,8 @@ const MessageBubble = ({ message, sender, isMe, chatId }) => {
         isOpen={showForwardModal}
         onClose={() => setShowForwardModal(false)}
         messageId={message._id}
-        users={[]}
-        groups={[]}
+        users={users}
+        groups={groups}
       />
     </>
   );


### PR DESCRIPTION
closes: #116

## Summary

This PR adds support for forwarding messages across private and group conversations.

## Changes

- Added forwarding metadata to the Message model
  - `isForwarded`
  - `originalMessageId`
- Implemented backend message forwarding API
- Added Socket.IO support for real-time forwarded messages
- Added "Forward" option to the message action menu
- Added conversation selection for forwarding messages
- Displayed a "Forwarded" indicator on forwarded messages

## Supported Forwarding

- ✅ Text messages
- ✅ Images
- ✅ Audio
- ✅ Documents
- ✅ Private chats
- ✅ Group chats
- ✅ Multiple destination conversations

## Testing

- Forwarded text messages
- Forwarded media messages
- Verified real-time synchronization via Socket.IO
- Verified existing messaging functionality remains unaffected

And I have attached a screen recording of working of the forward feature.

https://github.com/user-attachments/assets/d327a55c-9667-41b0-8f05-b1e795ce6193


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added message forwarding to one or more recipients, supporting both users and groups.
  * Added a “Forward” action that opens a recipient picker modal with selection validation, loading feedback, and success/error notifications.
  * Forwarded messages now display a “Forwarded” badge.
  * Forwarding preserves the original message content while enforcing access permissions.
* **Configuration**
  * Updated whitespace/formatting in the example environment file (no functional change).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->